### PR TITLE
Add model schema support for type Any

### DIFF
--- a/src/main/scala/com/iheart/playSwagger/Domain.scala
+++ b/src/main/scala/com/iheart/playSwagger/Domain.scala
@@ -1,5 +1,7 @@
 package com.iheart.playSwagger
 
+import play.api.libs.json.JsValue
+
 object Domain {
   type Path = String
   type Method = String
@@ -12,8 +14,8 @@ object Domain {
                                `type`: Option[String] = None,
                                format: Option[String] = None,
                                required: Boolean = true,
+                               example: Option[JsValue] = None,
                                referenceType: Option[String] = None,
                                items: Option[String] = None)
-
-
 }
+

--- a/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -2,6 +2,7 @@ package com.iheart.playSwagger
 
 import com.iheart.playSwagger.Domain.SwaggerParameter
 import org.joda.time.DateTime
+import play.api.libs.json.JsString
 
 object SwaggerParameterMapper {
   def mapParam(name: String, scalaTypeName: String, domainNameSpace: Option[String] = None): SwaggerParameter = {
@@ -34,6 +35,7 @@ object SwaggerParameterMapper {
           case "Double"   ⇒ prop("number", Some("double"))
           case "Float"    ⇒ prop("number", Some("float"))
           case "org.jodaTime.DateTime" ⇒ prop("integer", Some("epoch"))
+          case "Any"      ⇒ prop("any").copy(example = Some(JsString("any JSON value")))
           case unknown    ⇒ prop(unknown.toLowerCase())
         }
     }

--- a/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -31,10 +31,11 @@ case class SwaggerSpecGenerator(domainNameSpace: Option[String] = None, defaultP
     ))
 
   private val propFormat: Writes[SwaggerParameter] = (
-      (__ \ 'name ).write[String] ~
-      (__ \ 'type ).writeNullable[String] ~
-      (__ \ 'format ).writeNullable[String] ~
-      (__ \ 'required ).write[Boolean] ~
+      (__ \ 'name).write[String] ~
+      (__ \ 'type).writeNullable[String] ~
+      (__ \ 'format).writeNullable[String] ~
+      (__ \ 'required).write[Boolean] ~
+      (__ \ 'example).writeNullable[JsValue] ~
       referenceWrites("schema") ~
       referenceWrites("items", Json.obj("type" → "array"))
     )(unlift(SwaggerParameter.unapply))
@@ -66,9 +67,9 @@ case class SwaggerSpecGenerator(domainNameSpace: Option[String] = None, defaultP
     }.reduce(_ ++ _)
     val allRefs = (pathsJson ++ baseJson) \\ "$ref"
     val definitions = DefinitionGenerator(domainNameSpace).allDefinitions(allRefs.
-      map(_.asOpt[String]).collect{ case Some(s) ⇒ s }.
-      filter(s ⇒ domainNameSpace.fold(false)(ns ⇒ s.startsWith(referencePrefix + ns))).
-      map(_.drop(referencePrefix.length))
+      flatMap(_.asOpt[String]).
+      filter(s ⇒ domainNameSpace.exists(ns ⇒ s.startsWith(referencePrefix + ns))).
+      map(_.drop(referencePrefix.length)).
       toList)
 
     val definitionsJson = JsObject(definitions.map(d ⇒ d.name → Json.toJson(d)))
@@ -214,7 +215,4 @@ case class SwaggerSpecGenerator(domainNameSpace: Option[String] = None, defaultP
     JsObject(routesDocumentation.map(endPointEntry).collect { case Some(o) ⇒ o })
   }
 }
-
-
-
 

--- a/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -1,0 +1,26 @@
+package com.iheart.playSwagger
+
+import org.specs2.mutable.Specification
+import play.api.libs.json.JsString
+import com.iheart.playSwagger.Domain.SwaggerParameter
+
+class SwaggerParameterMapperSpec extends Specification {
+  "mapParam" >> {
+    import SwaggerParameterMapper.mapParam
+
+    "map org.jodaTime.DateTime to integer with format epoch" >> {
+      mapParam("fieldWithDateTime", "org.jodaTime.DateTime") === SwaggerParameter(
+        name = "fieldWithDateTime",
+        `type` = Option("integer"),
+        format = Option("epoch"))
+    }
+
+    "map Any to any with example value" >> {
+      mapParam("fieldWithAny", "Any") === SwaggerParameter(
+        name = "fieldWithAny",
+        `type` = Option("any"),
+        example = Option(JsString("any JSON value")))
+    }
+  }
+}
+


### PR DESCRIPTION
Provides example value for the Any type, allowing it to show up in the generated swagger model schema.
 
Fixes #5