### PR TITLE
fix build.properties filename

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.9

--- a/project/built.properties
+++ b/project/built.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.8


### PR DESCRIPTION
The misnamed `built.properties` file was causing sbt to fallback to the default (for me, 0.13.5), where `Resolver.bintrayRepo` was not yet defined, so I was seeing this error:

```
error: value bintrayRepo is not a member of object sbt.Resolver
```