### PR TITLE
add code coverage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,13 @@ scalaVersion in ThisBuild := "2.11.7"
 
 libraryDependencies ++= Dependencies.playJson ++ Dependencies.test ++ Dependencies.yaml
 
-
 licenses += ("Apache-2.0", url("http://www.apache.org/licenses/"))
 
 bintrayOrganization := Some("iheartradio")
 
 bintrayPackageLabels := Seq("play-framework", "swagger", "play")
+
+coverageMinimum := 85
+
+coverageFailOnMinimum := true
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")


### PR DESCRIPTION
This adds code coverage plugin. Run coverage with `;clean;coverage;test`. The output lists the file with the coverage report. The minimum coverage is set to slightly below what it's at currently (89%). If a contribution lowers that percentage, it should fail CI tests. The code is instrumented with local file references, so don't run `coverage` in the same sbt session when releasing.