### PR TITLE
Fixing Joda-Time package name

### DIFF
--- a/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -46,13 +46,13 @@ object SwaggerParameterMapper {
 
     def generalParam =
       (typeName match {
-        case "Int"                   ⇒ swaggerParam("integer", Some("int32"))
-        case "Long"                  ⇒ swaggerParam("integer", Some("int64"))
-        case "Double"                ⇒ swaggerParam("number", Some("double"))
-        case "Float"                 ⇒ swaggerParam("number", Some("float"))
-        case "org.jodaTime.DateTime" ⇒ swaggerParam("integer", Some("epoch"))
-        case "Any"                   ⇒ swaggerParam("any").copy(example = Some(JsString("any JSON value")))
-        case unknown                 ⇒ swaggerParam(unknown.toLowerCase())
+        case "Int"                    ⇒ swaggerParam("integer", Some("int32"))
+        case "Long"                   ⇒ swaggerParam("integer", Some("int64"))
+        case "Double"                 ⇒ swaggerParam("number", Some("double"))
+        case "Float"                  ⇒ swaggerParam("number", Some("float"))
+        case "org.joda.time.DateTime" ⇒ swaggerParam("integer", Some("epoch"))
+        case "Any"                    ⇒ swaggerParam("any").copy(example = Some(JsString("any JSON value")))
+        case unknown                  ⇒ swaggerParam(unknown.toLowerCase())
       }).copy(default = defaultValueO, required = defaultValueO.isEmpty)
 
     if (isReference()) referenceParam(typeName)

--- a/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -8,8 +8,8 @@ class SwaggerParameterMapperSpec extends Specification {
   "mapParam" >> {
     import SwaggerParameterMapper.mapParam
 
-    "map org.jodaTime.DateTime to integer with format epoch" >> {
-      mapParam("fieldWithDateTime", "org.jodaTime.DateTime") === SwaggerParameter(
+    "map org.joda.time.DateTime to integer with format epoch" >> {
+      mapParam("fieldWithDateTime", "org.joda.time.DateTime") === SwaggerParameter(
         name = "fieldWithDateTime",
         `type` = Option("integer"),
         format = Option("epoch")


### PR DESCRIPTION
Currently usage of model fields with type DateTime from Joda-Time is broken. The correct package name is "joda.time" instead of "jodaTime". (see here: http://www.joda.org/joda-time/apidocs/index.html )
(Note: I am pulling Joda-Time via dependency com.github.nscala-time" %% "nscala-time" % "2.6.0")
Because the package name does not match, the generated Swagger config contains the full package name instead of an integer. Therefore, the date field is missing in the Swagger UI all together.