### PR TITLE
Update sbt version and add Play 2.5 support

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val play = "[2.3.0, 2.4.+)"
+    val play = "[2.3.0, 2.5.+)"
     val specs2 = "3.6.6"
   }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.1-SNAPSHOT"
+version in ThisBuild := "0.2.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.2-SNAPSHOT"
+version in ThisBuild := "0.2.1-SNAPSHOT"


### PR DESCRIPTION
Needed some swagger in my APIs I am migrating to Play 2.5.

Tests pass, and my swagger docs are working again.