### PR TITLE
Support traits and Java enums

### DIFF
--- a/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
+++ b/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
@@ -17,7 +17,7 @@ final case class DefinitionGenerator(modelQualifier: DomainModelQualifier = Doma
   def definition(tpe: Type): Definition = {
     val fields = tpe.decls.collectFirst {
       case m: MethodSymbol if m.isPrimaryConstructor ⇒ m
-    }.get.paramLists.head
+    }.toList.flatMap(_.paramLists).headOption.getOrElse(Nil)
 
     val properties = fields.map { field ⇒
       //TODO: find a better way to get the string representation of typeSignature

--- a/src/main/scala/com/iheart/playSwagger/Domain.scala
+++ b/src/main/scala/com/iheart/playSwagger/Domain.scala
@@ -20,7 +20,8 @@ object Domain {
     default:       Option[JsValue]          = None,
     example:       Option[JsValue]          = None,
     referenceType: Option[String]           = None,
-    items:         Option[SwaggerParameter] = None
+    items:         Option[SwaggerParameter] = None,
+    enum:          Option[Seq[String]]      = None
   )
 }
 

--- a/src/test/resources/test.routes
+++ b/src/test/resources/test.routes
@@ -21,3 +21,21 @@ GET  /abc                  com.iheart.Application.test()
 #        $ref: '#/definitions/com.iheart.playSwagger.FooWithSeq2'
 ###
 POST /post-body            com.iheart.Application.postBody()
+
+###
+#  parameters:
+#    - name: body
+#      description: polymorphic example
+#      schema:
+#        $ref: '#/definitions/com.iheart.playSwagger.PolymorphicContainer'
+###
+POST     /somethingPolymorphic             controllers.Player.somethingPolymorphic()
+
+###
+#  parameters:
+#    - name: body
+#      description: java enum example
+#      schema:
+#        $ref: '#/definitions/com.iheart.playSwagger.JavaEnumContainer'
+###
+POST     /somethingWithEnum                controllers.Player.somethingWithEnum()

--- a/src/test/scala/com/iheart/playSwagger/SampleJavaEnum.java
+++ b/src/test/scala/com/iheart/playSwagger/SampleJavaEnum.java
@@ -1,0 +1,5 @@
+package com.iheart.playSwagger;
+
+public enum SampleJavaEnum {
+    DISABLED, ACTIVE
+}

--- a/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -9,6 +9,11 @@ case class Artist(name: String, age: Int)
 case class Student(name: String, teacher: Option[Teacher])
 case class Teacher(name: String)
 
+case class PolymorphicContainer(item: PolymorphicItem)
+trait PolymorphicItem
+
+case class JavaEnumContainer(status: SampleJavaEnum)
+
 class SwaggerSpecGeneratorSpec extends Specification {
   implicit val cl = getClass.getClassLoader
 
@@ -34,6 +39,9 @@ class SwaggerSpecGeneratorSpec extends Specification {
     lazy val trackJson = (definitionsJson \ "com.iheart.playSwagger.Track").as[JsObject]
     lazy val studentJson = (definitionsJson \ "com.iheart.playSwagger.Student").asOpt[JsObject]
     lazy val teacherJson = (definitionsJson \ "com.iheart.playSwagger.Teacher").asOpt[JsObject]
+    lazy val polymorphicContainerJson = (definitionsJson \ "com.iheart.playSwagger.PolymorphicContainer").asOpt[JsObject]
+    lazy val polymorphicItemJson = (definitionsJson \ "com.iheart.playSwagger.PolymorphicItem").asOpt[JsObject]
+    lazy val javaEnumContainerJson = (definitionsJson \ "com.iheart.playSwagger.JavaEnumContainer").asOpt[JsObject]
 
     def parametersOf(json: JsValue): Seq[JsValue] = {
       (json \ "parameters").as[JsArray].value
@@ -91,6 +99,18 @@ class SwaggerSpecGeneratorSpec extends Specification {
 
       (artistDefJson \ "properties" \ "age" \ "type").as[String] === "integer"
     }
+
+    "read trait with container" >> {
+      polymorphicContainerJson must beSome[JsObject]
+      (polymorphicContainerJson.get \ "properties" \ "item" \ "schema" \ "$ref").asOpt[String] === Some("#/definitions/com.iheart.playSwagger.PolymorphicItem")
+      polymorphicItemJson must beSome[JsObject]
+    }
+
+    "read java enum with container" >> {
+      javaEnumContainerJson must beSome[JsObject]
+      (javaEnumContainerJson.get \ "properties" \ "status" \ "enum").asOpt[Seq[String]] === Some(Seq("DISABLED", "ACTIVE"))
+    }
+
 
     "definition property have no name" >> {
       (artistDefJson \ "properties" \ "age" \ "name").toOption must beEmpty


### PR DESCRIPTION
1. Avoid definition generator crash on traits
`DefinitionGenerator.definition()` was failing with `None.get` error if some class references a trait. 
Now it doesn't crash and generate an empty spec for trait. 
2. Support Java enums
Earlier Java enums resulted in empty object definition.
Now in accordance with http://swagger.io/specification/ it creates `"string"` field with  `"enum": [...]` array describing valid values.