### PR TITLE
Fix classloading for Java enums support

### DIFF
--- a/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -8,7 +8,7 @@ import scala.util.Try
 
 object SwaggerParameterMapper {
 
-  def mapParam(parameter: Parameter, modelQualifier: DomainModelQualifier = DomainModelQualifier()): SwaggerParameter = {
+  def mapParam(parameter: Parameter, modelQualifier: DomainModelQualifier = DomainModelQualifier())(implicit cl: ClassLoader): SwaggerParameter = {
 
     def higherOrderType(higherOrder: String, typeName: String): Option[String] = {
       s"$higherOrder\\[(\\S+)\\]".r.findFirstMatchIn(typeName).map(_.group(1))
@@ -34,7 +34,7 @@ object SwaggerParameterMapper {
     }
 
     def getJavaEnum(tpeName: String): Option[Class[java.lang.Enum[_]]] = {
-      Try(Class.forName(tpeName)).toOption.filter(_.isEnum).map(_.asInstanceOf[Class[java.lang.Enum[_]]])
+      Try(cl.loadClass(tpeName)).toOption.filter(_.isEnum).map(_.asInstanceOf[Class[java.lang.Enum[_]]])
     }
 
     def enumParam(tpeName: String) = {
@@ -70,8 +70,8 @@ object SwaggerParameterMapper {
 
     lazy val itemTypeO = collectionItemType(typeName)
 
-    if (getJavaEnum(typeName).isDefined)  enumParam(typeName)
-    else if(isReference()) referenceParam(typeName)
+    if (getJavaEnum(typeName).isDefined) enumParam(typeName)
+    else if (isReference()) referenceParam(typeName)
     else if (optionalTypeO.isDefined)
       optionalParam(optionalTypeO.get)
     else if (itemTypeO.isDefined)

--- a/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -163,9 +163,9 @@ final case class SwaggerSpecGenerator(
 
   implicit class PathAdditions(path: JsPath) {
     def writeNullableIterable[A <: Iterable[_]](implicit writes: Writes[A]): OWrites[A] =
-      OWrites[A] { (a: A) =>
+      OWrites[A] { (a: A) ⇒
         if (a.isEmpty) Json.obj()
-        else JsPath.createObj(path -> writes.writes(a))
+        else JsPath.createObj(path → writes.writes(a))
       }
   }
 

--- a/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -8,6 +8,7 @@ import play.routes.compiler.Parameter
 class SwaggerParameterMapperSpec extends Specification {
   "mapParam" >> {
     import SwaggerParameterMapper.mapParam
+    implicit val cl = this.getClass.getClassLoader
 
     "map org.joda.time.DateTime to integer with format epoch" >> {
       mapParam(Parameter("fieldWithDateTime", "org.joda.time.DateTime", None, None)) === SwaggerParameter(

--- a/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -111,7 +111,6 @@ class SwaggerSpecGeneratorSpec extends Specification {
       (javaEnumContainerJson.get \ "properties" \ "status" \ "enum").asOpt[Seq[String]] === Some(Seq("DISABLED", "ACTIVE"))
     }
 
-
     "definition property have no name" >> {
       (artistDefJson \ "properties" \ "age" \ "name").toOption must beEmpty
     }


### PR DESCRIPTION
Previous pull request added support for Java enums, but it only worked only if enums are defined in "play-swagger" project itself :-) . Enum class could not be located if "play-swagger" is used as library in Play application. Now fixed it.