### PR TITLE
prototype macro swagger compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,24 +1,48 @@
 
-organization in ThisBuild := "com.iheart"
+lazy val commonSettings = Seq(
+  organization := "com.iheart",
+  scalaVersion := "2.11.7",
+  scalacOptions in (Compile, compile) ++= Seq(
+    "-encoding", "UTF-8",
+    "-deprecation", // warning and location for usages of deprecated APIs
+    "-feature", // warning and location for usages of features that should be imported explicitly
+    "-unchecked", // additional warnings where generated code depends on assumptions
+    "-Xlint", // recommended additional warnings
+    "-Ywarn-adapted-args", // Warn if an argument list is modified to match the receiver
+    "-Ywarn-inaccessible",
+    "-Ywarn-dead-code",
+    "-Ywarn-numeric-widen"
+  )
+) ++
+  Publish.settings ++
+  Testing.settings ++
+  Format.settings
 
-name := "play-swagger"
+lazy val playSwagger = (project in file("."))
+  .dependsOn(macros)
+  .settings(commonSettings:_*)
+  .settings(
+    name := "play-swagger",
+    resolvers +=  Resolver.bintrayRepo("scalaz", "releases"),
+    libraryDependencies ++=
+      Dependencies.playTest ++
+      Dependencies.playRoutesCompiler ++
+      Dependencies.playJson ++
+      Dependencies.test ++
+      Dependencies.yaml ++ Seq(
+        "com.chuusai" %% "shapeless" % "2.3.0" % "provided"
+      )
+  )
 
-resolvers +=  Resolver.bintrayRepo("scalaz", "releases")
 
-scalaVersion in ThisBuild := "2.11.7"
-
-libraryDependencies ++=
-  Dependencies.playTest ++
-  Dependencies.playRoutesCompiler ++
-  Dependencies.playJson ++
-  Dependencies.test ++
-  Dependencies.yaml
-
-Publish.settings
-
-lazy val playSwagger = project in file(".")
-
-Testing.settings
-
-Format.settings
-
+lazy val macros = project
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.typelevel" %% "macro-compat" % "1.1.1",
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided",
+      "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
+      "com.typesafe.play" %% "routes-compiler" % "2.4.6",
+      "com.chuusai" %% "shapeless" % "2.3.0" % "provided"
+    )
+  )
+  .settings(commonSettings:_*)

--- a/macros/src/main/scala/com/iheart/playSwagger/Liftables.scala
+++ b/macros/src/main/scala/com/iheart/playSwagger/Liftables.scala
@@ -1,0 +1,134 @@
+package com.iheart.playSwagger
+
+/*
+ * Copyright (c) 2016 Jan Bessai, Miles Sabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// taken from an unmerged PR to shapeless: https://github.com/milessabin/shapeless/pull/577/files
+
+import scala.reflect.api.Universe
+import shapeless._
+
+// Typically the contents of this trait will be accessed by mixing it into the usage context.
+trait Liftables {
+  val universe: Universe
+  import universe._
+
+  /**
+   * Generically derived `Liftable` instances to quote data types.
+   * See the [[http://docs.scala-lang.org/overviews/quasiquotes/lifting documentation on quasi quotes]]
+   * for an explanation of lifting.
+   *
+   * @author Jan Bessai
+   */
+  trait GenericLiftable[T] {
+    def liftable: Liftable[T]
+  }
+
+  object GenericLiftable extends StandardInstances {
+    def apply[T](implicit lt: GenericLiftable[T]): Liftable[T] = lt.liftable
+  }
+
+  trait AlgebraicInstances {
+    implicit final def liftHCons[H, T <: HList](
+      implicit
+      lh:   Cached[GenericLiftable[H]],
+      lt:   Cached[GenericLiftable[T]],
+      htag: WeakTypeTag[H],
+      ttag: WeakTypeTag[T]
+    ): GenericLiftable[H :: T] =
+      new GenericLiftable[H :: T] {
+        val liftable: Liftable[H :: T] =
+          new Liftable[H :: T] {
+            def apply(x: H :: T) =
+              q"""_root_.shapeless.::[${htag.tpe}, ${ttag.tpe}](
+                ${lh.value.liftable(x.head)},
+                ${lt.value.liftable(x.tail)})
+              """
+          }
+      }
+
+    implicit val liftHNil: GenericLiftable[HNil] = new GenericLiftable[HNil] {
+      def liftable: Liftable[HNil] =
+        new Liftable[HNil] {
+          def apply(x: HNil) =
+            q"_root_.shapeless.HNil"
+        }
+    }
+
+    implicit final def liftCCons[L, R <: Coproduct](
+      implicit
+      ll:   Cached[GenericLiftable[L]],
+      lr:   Cached[GenericLiftable[R]],
+      ltag: WeakTypeTag[L],
+      rtag: WeakTypeTag[R]
+    ): GenericLiftable[L :+: R] =
+      new GenericLiftable[L :+: R] {
+        val liftable: Liftable[L :+: R] =
+          new Liftable[L :+: R] {
+            def apply(x: L :+: R) =
+              x match {
+                case Inl(l) ⇒
+                  q"_root_.shapeless.Inl[${ltag.tpe}, ${rtag.tpe}](${ll.value.liftable(l)})"
+                case Inr(r) ⇒
+                  q"_root_.shapeless.Inr[${ltag.tpe}, ${rtag.tpe}](${lr.value.liftable(r)})"
+              }
+          }
+      }
+
+    implicit val liftCNil = new GenericLiftable[CNil] {
+      val liftable: Liftable[CNil] =
+        new Liftable[CNil] {
+          def apply(x: CNil) =
+            q"_root_.shapeless.CNil"
+        }
+    }
+  }
+
+  trait GenericInstances extends AlgebraicInstances {
+    implicit final def liftGeneric[T, Repr](
+      implicit
+      loprio: LowPriority,
+      gen:    Generic.Aux[T, Repr],
+      lrepr:  Cached[Lazy[GenericLiftable[Repr]]],
+      tag:    WeakTypeTag[T]
+    ): GenericLiftable[T] =
+      new GenericLiftable[T] {
+        val liftable: Liftable[T] =
+          new Liftable[T] {
+            def apply(x: T) =
+              q"""_root_.shapeless.Generic[${tag.tpe}].from(
+                    ${lrepr.value.value.liftable(gen.to(x))})"""
+          }
+      }
+  }
+
+  trait StandardInstances extends GenericInstances {
+    implicit final def liftStandard[T](implicit lift: Liftable[T]): GenericLiftable[T] = new GenericLiftable[T] {
+      val liftable = lift
+    }
+  }
+}
+
+/**
+ * Derive `Liftable` in runtime universes.
+ * Due to [[https://issues.scala-lang.org/browse/SI-6636 SI-6636]] only runtime toolboxes
+ * from Scala 2.11.8 and above can compile the quoted code.
+ *
+ * @author Jan Bessai
+ */
+trait RuntimeLiftables extends Liftables {
+  val universe: scala.reflect.runtime.universe.type = scala.reflect.runtime.universe
+}

--- a/macros/src/main/scala/com/iheart/playSwagger/Macros.scala
+++ b/macros/src/main/scala/com/iheart/playSwagger/Macros.scala
@@ -1,0 +1,144 @@
+package com.iheart.playSwagger
+
+import java.io.{BufferedWriter, File, FileWriter, PrintWriter}
+
+import play.routes.compiler._
+
+import scala.io.Source
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+sealed trait Routing extends Product with Serializable
+case class RouteFile(prefix: String, file: String, routes: List[Routing]) extends Routing
+case class RouteDef(route: Route) extends Routing
+
+object Macros {
+
+  def apply(routes: String): Seq[Route] = macro routesImpl
+
+  def all(routesFile: String): Routing = macro allImpl
+
+  def allImpl(c: blackbox.Context)(routesFile: c.Expr[String]): c.Expr[Routing] = {
+    import c.universe._
+    val liftables = new RouteLiftables {
+      val universe: c.universe.type = c.universe
+    }
+    import liftables._
+
+    val fileName = c.eval(c.Expr[String](c.untypecheck(routesFile.tree.duplicate)))
+    val file = new File(fileName)
+
+    val parent = file.getParentFile
+
+    def readFile(fileName: String): util.Try[String] = util.Try {
+      var source: Source = null
+      try {
+        source = Source.fromFile(new File(parent, fileName))
+        source.mkString
+      } finally {
+        if (source != null) source.close()
+      }
+    }
+
+    def parse(prefix: String, fileName: String): Routing = {
+      def loop(fileName: String): List[Routing] = {
+        readFile(fileName) match {
+          case util.Success(content) ⇒
+            RoutesFileParser.parseContent(content, file).fold({ errors ⇒
+              val lines = content.split('\n')
+              val message = errors.map(errorMessage(lines, _)).mkString("\n")
+              c.abort(c.enclosingPosition, message)
+            }, { routes ⇒
+              routes.foldLeft[List[Routing]](Nil) {
+                case (acc, route: Route) ⇒
+                  acc :+ RouteDef(route)
+                case (acc, include @ Include(prefix, router)) ⇒
+                  val reference = router.replace(".Routes", ".routes")
+                  acc :+ parse(prefix, reference)
+              }
+            })
+          case util.Failure(error) ⇒
+            c.warning(c.enclosingPosition, s"Skipping file $fileName")
+            Nil
+        }
+      }
+      RouteFile(prefix, fileName, loop(fileName))
+    }
+
+    def errorMessage(lines: Seq[String], error: RoutesCompilationError) = {
+      val lineNumber = error.line.fold("")(":" + _ + error.column.fold("")(":" + _))
+      val errorLine = error.line.flatMap { line ⇒
+        val caret = error.column.map(c ⇒ (" " * (c - 1)) + "^").getOrElse("")
+        lines.lift(line - 1).map(_ + "\n" + caret)
+      }.getOrElse("")
+      s"""|Error parsing routes file: ${error.source.getAbsolutePath}$lineNumber:\n
+          |${error.message}
+          |$errorLine
+          |""".stripMargin
+    }
+
+    val result = parse("/", file.getName)
+    c.Expr[Routing](q"$result")
+  }
+
+  def routesImpl(c: blackbox.Context)(routes: c.Expr[String]): c.Expr[Seq[Route]] = {
+    import c.universe._
+    val liftables = new RouteLiftables {
+      val universe: c.universe.type = c.universe
+    }
+    import liftables._
+
+    val content = c.eval(c.Expr[String](c.untypecheck(routes.tree.duplicate)))
+
+    // These generic liftables avoid having to write Liftable instances by hand, or write custom quasiquotes for an ADT
+
+    implicitly[Liftable[Route]]
+
+    val file = writeRoutesFile(c)(content)
+
+    val result = RoutesFileParser.parseContent(content, file).right.flatMap { routes ⇒
+      routes.foldLeft[Either[Seq[RoutesCompilationError], Seq[Route]]](Right(Vector.empty[Route])) {
+        case (Right(acc), route: Route) ⇒ Right(acc :+ route)
+        case (l @ Left(_), _)           ⇒ l
+        case (_, _)                     ⇒ Left(Seq(RoutesCompilationError(file, "doesn't support anything but route", None, None)))
+      }
+    }
+
+    def errorMessage(lines: Seq[String], error: RoutesCompilationError) = {
+      val lineNumber = error.line.fold("")(":" + _ + error.column.fold("")(":" + _))
+      val errorLine = error.line.flatMap { line ⇒
+        val caret = error.column.map(c ⇒ (" " * (c - 1)) + "^").getOrElse("")
+        lines.lift(line - 1).map(_ + "\n" + caret)
+      }.getOrElse("")
+      s"""|Error parsing routes file: ${error.source.getAbsolutePath}$lineNumber:\n
+          |${error.message}
+          |$errorLine
+          |""".stripMargin
+    }
+
+    result match {
+      case Left(errors) ⇒
+        val lines = content.split('\n')
+        val message = errors.map(errorMessage(lines, _)).mkString("\n")
+        c.abort(c.enclosingPosition, message)
+      case Right(results) ⇒ c.Expr[Seq[Route]](q"$results")
+    }
+  }
+
+  //TODO: switch to macro-compat
+  def writeRoutesFile(c: blackbox.Context)(content: String): File = {
+    val file = File.createTempFile("routes-compiler-", ".routes")
+    // TODO: switch to info, so that -verbose is required to see it? (only for debugging)
+    c.echo(c.universe.NoPosition, s"Writing routes file to ${file.getCanonicalPath}")
+    file.deleteOnExit()
+    val out = new PrintWriter(new BufferedWriter(new FileWriter(file)))
+    try {
+      out.println(content)
+    } finally {
+      out.close()
+    }
+    file
+  }
+
+}
+

--- a/macros/src/main/scala/com/iheart/playSwagger/RouteLiftables.scala
+++ b/macros/src/main/scala/com/iheart/playSwagger/RouteLiftables.scala
@@ -1,0 +1,36 @@
+package com.iheart.playSwagger
+
+import play.routes.compiler._
+
+trait RouteLiftables extends Liftables {
+  import universe._
+
+  // No seq liftable exists, most likely because it's a generic interface and the generated tree would have to choose
+  // some implementation. This simply defers to Seq's companion object
+  implicit def seqLiftable[A](implicit l: Liftable[A]): Liftable[Seq[A]] =
+    Liftable[Seq[A]](f ⇒ q"_root_.scala.collection.Seq(..$f)")
+
+  // Ideally, none of these instances would be required, but PathPart causes us to need one custom instance, and the
+  // GenericLiftable implicit resolution hangs indefinitely after that.
+
+  implicit lazy val dynamicPartLiftable = GenericLiftable[DynamicPart]
+  implicit lazy val staticPartLiftable = GenericLiftable[StaticPart]
+
+  // PathPart is not a sealed trait, so it's children cannot be found by shapeless, so a custom Liftable is required
+  implicit lazy val pathPartLiftable: Liftable[PathPart] = new Liftable[PathPart] {
+    def apply(part: PathPart) = part match {
+      case d: DynamicPart ⇒ dynamicPartLiftable(d)
+      case s: StaticPart  ⇒ staticPartLiftable(s)
+    }
+  }
+
+  implicit lazy val parameterLiftable = GenericLiftable[Parameter]
+  implicit lazy val handlerLiftable = GenericLiftable[HandlerCall]
+  implicit lazy val httpVerbLiftable = GenericLiftable[HttpVerb]
+  implicit lazy val pathPatternLiftable = GenericLiftable[PathPattern]
+  implicit lazy val commentLiftable = GenericLiftable[Comment]
+  implicit lazy val routeLiftable = GenericLiftable[Route]
+
+  implicit lazy val routesLiftable = GenericLiftable[Routing]
+
+}

--- a/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -50,14 +50,16 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
 
   "integration" >> {
 
-    lazy val defaultRoutesFile = SwaggerSpecGenerator("com.iheart").generate()
+    lazy val routes = Macros.all("src/test/resources/routes")
+    lazy val defaultRoutesFile = SwaggerSpecGenerator("com.iheart").generate(routes)
 
     "Use default routes file when no argument is given" >> {
-      val json = defaultRoutesFile.get
+      val json = defaultRoutesFile
       (json \ "paths" \ "/player/{pid}/context/{bid}").asOpt[JsObject] must beSome
     }
 
-    lazy val json = SwaggerSpecGenerator("com.iheart").generate("test.routes").get
+    lazy val testRoutes = Macros.all("src/test/resources/test.routes")
+    lazy val json = SwaggerSpecGenerator("com.iheart").generate(testRoutes)
     lazy val pathJson = json \ "paths"
     lazy val definitionsJson = json \ "definitions"
     lazy val postBodyJson = (pathJson \ "/post-body" \ "post").as[JsObject]


### PR DESCRIPTION
This is a proof of concept for generating docs at compile to catch errors more quickly. Currently, it only runs the play routes compilation and should be extended to do the swagger doc compilation. It should also be made optional (this pr replaces the runtime mechanism entirely).

One issue I found with this approach is that modifying a routes file doesn't trigger recompilation of the file calling the macro. Recompilation only happens when the scala file calling the macro itself is invalidated (or obviously after a clean).