### PR TITLE
Extract a trait for the DomainModelQualifier

### DIFF
--- a/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
+++ b/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
@@ -6,7 +6,7 @@ import play.routes.compiler.Parameter
 
 import scala.reflect.runtime.universe._
 
-final case class DefinitionGenerator(modelQualifier: DomainModelQualifier = DomainModelQualifier())(implicit cl: ClassLoader) {
+final case class DefinitionGenerator(modelQualifier: DomainModelQualifier = PrefixDomainModelQualifier())(implicit cl: ClassLoader) {
 
   def dealiasParams(t: Type): Type = {
     appliedType(t.dealias.typeConstructor, t.typeArgs.map { arg ⇒
@@ -69,5 +69,5 @@ final case class DefinitionGenerator(modelQualifier: DomainModelQualifier = Doma
 }
 
 object DefinitionGenerator {
-  def apply(domainNameSpace: String)(implicit cl: ClassLoader): DefinitionGenerator = DefinitionGenerator(DomainModelQualifier(domainNameSpace))
+  def apply(domainNameSpace: String)(implicit cl: ClassLoader): DefinitionGenerator = DefinitionGenerator(PrefixDomainModelQualifier(domainNameSpace))
 }

--- a/src/main/scala/com/iheart/playSwagger/DomainModelQualifier.scala
+++ b/src/main/scala/com/iheart/playSwagger/DomainModelQualifier.scala
@@ -1,5 +1,9 @@
 package com.iheart.playSwagger
 
-final case class DomainModelQualifier(namespaces: String*) {
+trait DomainModelQualifier {
+  def isModel(className: String): Boolean
+}
+
+final case class PrefixDomainModelQualifier(namespaces: String*) extends DomainModelQualifier {
   def isModel(className: String): Boolean = namespaces exists className.startsWith
 }

--- a/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -8,7 +8,7 @@ import scala.util.Try
 
 object SwaggerParameterMapper {
 
-  def mapParam(parameter: Parameter, modelQualifier: DomainModelQualifier = DomainModelQualifier())(implicit cl: ClassLoader): SwaggerParameter = {
+  def mapParam(parameter: Parameter, modelQualifier: DomainModelQualifier = PrefixDomainModelQualifier())(implicit cl: ClassLoader): SwaggerParameter = {
 
     def higherOrderType(higherOrder: String, typeName: String): Option[String] = {
       s"$higherOrder\\[(\\S+)\\]".r.findFirstMatchIn(typeName).map(_.group(1))

--- a/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -14,11 +14,11 @@ import scala.util.{Try, Success, Failure}
 
 object SwaggerSpecGenerator {
   private val marker = "##"
-  def apply(domainNameSpaces: String*)(implicit cl: ClassLoader): SwaggerSpecGenerator = SwaggerSpecGenerator(DomainModelQualifier(domainNameSpaces: _*))
+  def apply(domainNameSpaces: String*)(implicit cl: ClassLoader): SwaggerSpecGenerator = SwaggerSpecGenerator(PrefixDomainModelQualifier(domainNameSpaces: _*))
 }
 
 final case class SwaggerSpecGenerator(
-  modelQualifier:        DomainModelQualifier = DomainModelQualifier(),
+  modelQualifier:        DomainModelQualifier = PrefixDomainModelQualifier(),
   defaultPostBodyFormat: String               = "application/json"
 )(implicit cl: ClassLoader) {
 

--- a/src/test/resources/swagger.json
+++ b/src/test/resources/swagger.json
@@ -4,5 +4,18 @@
        "name" : "player",
        "description": "this is player api"
     }
-  ]
+  ],
+  "definitions": {
+    "com.iheart.playSwagger.DictType": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    }
+  }
 }

--- a/src/test/scala/com/iheart/playSwagger/PrefixDomainModelQualifierSpec.scala
+++ b/src/test/scala/com/iheart/playSwagger/PrefixDomainModelQualifierSpec.scala
@@ -2,10 +2,10 @@ package com.iheart.playSwagger
 
 import org.specs2.mutable.Specification
 
-class DomainModelQualifierSpec extends Specification {
+class PrefixDomainModelQualifierSpec extends Specification {
   "isModel with multiple packages" >> {
 
-    val dmq = DomainModelQualifier("com.a", "com.b")
+    val dmq = PrefixDomainModelQualifier("com.a", "com.b")
 
     "returns true if the class is in one of the packages" >> {
 
@@ -19,7 +19,7 @@ class DomainModelQualifierSpec extends Specification {
 
   "isModel with no packages" >> {
     "returns false" >> {
-      val dmq = DomainModelQualifier()
+      val dmq = PrefixDomainModelQualifier()
       dmq.isModel("com.c.foo") must beFalse
     }
   }


### PR DESCRIPTION
This enables customisation of domain model introspection, eg. for excluding specific classes from the definition generation such that they can be completely customised in the swagger.json file.

See `excluded domain object should contain only spec from swagger.json` test for example.