### PR TITLE
Upgrade to PLAY 2.5

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val play = "[2.3.0, 2.4.+)"
+    val play = "2.5.3"
     val specs2 = "3.6.6"
   }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.9
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.1")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.4-SNAPSHOT"
+version in ThisBuild := "0.4.0-SNAPSHOT"


### PR DESCRIPTION
It's time to swap main branch to play 2.5 now. We will maintain a play2.4 branch for backward compatibility. I will release 0.4.0 after this is merged and submit a PR updating the README. 