### PR TITLE
use build info instead of a resource file to track version 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ cache:
   - $HOME/.sbt/boot/
 
 script:
-  - sbt clean sbtPlaySwagger/test playSwagger/coverage playSwagger/test
+  - sbt clean sbtPlaySwagger/test
+  - sbt ';project playSwagger;clean;coverage;test'
 after_success:
-  - sbt playSwagger/coverageReport playSwagger/coveralls
+  - sbt ';project playSwagger;coverageReport;coveralls'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ cache:
 script:
   - sbt clean sbtPlaySwagger/test playSwagger/coverage playSwagger/test
 after_success:
-  - sbt playSwagger/coveralls
+  - sbt playSwagger/coverageReport playSwagger/coveralls

--- a/build.sbt
+++ b/build.sbt
@@ -25,12 +25,13 @@ lazy val playSwagger = project.in(file("core"))
 lazy val sbtPlaySwagger = project.in(file("sbtPlugin"))
   .settings(Publish.sbtPluginSettings ++ Format.settings ++ ScriptedTesting.settings)
   .settings(addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.6" % Provided))
-  .disablePlugins(ScoverageSbtPlugin)
+  .enablePlugins(BuildInfoPlugin)
   .settings(
+    buildInfoKeys := Seq[BuildInfoKey](name, version),
+    buildInfoPackage := "com.iheart.playSwagger",
     name := "sbt-play-swagger",
     description := "sbt plugin for play swagger spec generation",
     sbtPlugin := true,
     scalaVersion := "2.10.6",
-    resourceGenerators in Compile <+= Versioning.writeVersionFile("com/iheart/play-swagger.version"),
     scripted <<= scripted.dependsOn(publishLocal in playSwagger)
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,3 +10,4 @@ addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
 
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,10 +4,10 @@ addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
-
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
+
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
@@ -10,7 +10,7 @@ import sbt.{AutoPlugin, _}
 
 object SwaggerPlugin extends AutoPlugin {
   lazy val swaggerConfig = config("play-swagger").hide
-  lazy val playSwaggerVersion = read(getResource("com/iheart/play-swagger.version"), UTF_8)
+  lazy val playSwaggerVersion = com.iheart.playSwagger.BuildInfo.version
 
   object autoImport extends SwaggerKeys
 


### PR DESCRIPTION
the resource file way, for unknown reason didn't work with play 2.4 branch. 