### PR TITLE
Added a filter to remove "fixed" parameters that the client cannot see or set.

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -287,8 +287,11 @@ final case class SwaggerSpecGenerator(
         case d: DynamicPart ⇒ d.name
       }.toSet
 
-      val params = route.call.parameters
-        .fold(Seq.empty[SwaggerParameter])(_.map(mapParam(_, modelQualifier)))
+      val params = for {
+        paramList ← route.call.parameters.toSeq
+        param ← paramList
+        if param.fixed.isEmpty // Removes parameters the client cannot set
+      } yield mapParam(param, modelQualifier)
 
       JsArray(params.map { p ⇒
         val jo = Json.toJson(p)(paramFormat).as[JsObject]

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
@@ -31,12 +31,6 @@ TaskKey[Unit]("check") := {
       |            },
       |            "parameters":[
       |               {
-      |                  "name":"path",
-      |                  "type":"string",
-      |                  "required":true,
-      |                  "in":"query"
-      |               },
-      |               {
       |                  "name":"trackId",
       |                  "type":"asset",
       |                  "required":true,


### PR DESCRIPTION
"Fixed" parameters are those that are assigned with an = in the route file, often seen with Assets "path" etc, eg:

`GET    /tracks/:trackId             controllers.Assets.versioned(path="/public/assets", trackId: Asset)`

Fixed a test that was requiring those parameters to be passed through.  I suspect this test was generated using the existing output as an expectation.