### PR TITLE
Fixing to match how Play processes nested "/" routes.

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -260,12 +260,8 @@ final case class SwaggerSpecGenerator(
   }
 
   private[playSwagger] def fullPath(prefix: String, inRoutePath: String): String =
-    "/" +
-      List(
-        prefix.stripPrefix("/").stripSuffix("/"),
-        inRoutePath.stripPrefix("/")
-      ).filterNot(_.isEmpty).
-        mkString("/")
+    "/" + Some(prefix.stripPrefix("/").stripSuffix("/")).filterNot(_.isEmpty)
+      .map(_ + "/").getOrElse("") + inRoutePath.stripPrefix("/")
 
   // Multiple routes may have the same path, merge the objects instead of overwriting
 

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -41,6 +41,10 @@ class SwaggerSpecGeneratorSpec extends Specification {
       gen.fullPath("p/", "/d//c") === "/p/d//c"
     }
 
+    "respect top level trailing slash" >> {
+      gen.fullPath("p/", "/") === "/p/"
+    }
+
   }
 
 }
@@ -66,7 +70,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     lazy val addTrackJson = (pathJson \ "/api/station/playedTracks" \ "post").as[JsObject]
     lazy val playerJson = (pathJson \ "/api/player/{pid}/context/{bid}" \ "get").as[JsObject]
     lazy val playerAddTrackJson = (pathJson \ "/api/player/{pid}/playedTracks" \ "post").as[JsObject]
-    lazy val resourceJson = (pathJson \ "/api/resource").as[JsObject]
+    lazy val resourceJson = (pathJson \ "/api/resource/").as[JsObject]
     lazy val allOptionalDefJson = (definitionsJson \ "com.iheart.playSwagger.AllOptional").as[JsObject]
     lazy val artistDefJson = (definitionsJson \ "com.iheart.playSwagger.Artist").as[JsObject]
     lazy val trackJson = (definitionsJson \ "com.iheart.playSwagger.Track").as[JsObject]
@@ -217,7 +221,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     }
 
     "parse controller with custom namespace" >> {
-      (pathJson \ "/api/customResource" \ "get").asOpt[JsObject] must beSome[JsObject]
+      (pathJson \ "/api/customResource/" \ "get").asOpt[JsObject] must beSome[JsObject]
     }
 
     "parse class referenced in option type" >> {


### PR DESCRIPTION
routes:
`/thing -> thing.Routes`

thing.routes:
`GET / controllers.MyController.thingFetcher`

The resulting path is `/thing/`, old was yielding `/thing` and Play will not match /thing

Fixed fullPath generator to account for this
Added test in fullPath portion of spec to explicitly test for this case.