### PR TITLE
Adding support for Scala enums in SwaggerParameterMapper

### DIFF
--- a/core/src/test/resources/test.routes
+++ b/core/src/test/resources/test.routes
@@ -40,7 +40,7 @@ POST     /somethingPolymorphic             controllers.Player.somethingPolymorph
 #    - name: body
 #      description: java enum example
 #      schema:
-#        $ref: '#/definitions/com.iheart.playSwagger.JavaEnumContainer'
+#        $ref: '#/definitions/com.iheart.playSwagger.EnumContainer'
 ###
 POST     /somethingWithEnum                controllers.Player.somethingWithEnum()
 

--- a/core/src/test/scala/com/iheart/playSwagger/SampleScalaEnum.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SampleScalaEnum.scala
@@ -1,0 +1,8 @@
+package com.iheart.playSwagger
+
+object SampleScalaEnum extends Enumeration {
+  type SampleScalaEnum = Value
+
+  val One = Value
+  val Two = Value
+}

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -71,6 +71,22 @@ class SwaggerParameterMapperSpec extends Specification {
       )
     }
 
+    "map java enum to enum constants" >> {
+      mapParam(Parameter("javaEnum", "com.iheart.playSwagger.SampleJavaEnum", None, None)) === GenSwaggerParameter(
+        name = "javaEnum",
+        `type` = Option("string"),
+        enum = Option(Seq("DISABLED", "ACTIVE"))
+      )
+    }
+
+    "map scala enum to enum constants" >> {
+      mapParam(Parameter("scalaEnum", "com.iheart.playSwagger.SampleScalaEnum.Value", None, None)) === GenSwaggerParameter(
+        name = "scalaEnum",
+        `type` = Option("string"),
+        enum = Option(Seq("One", "Two"))
+      )
+    }
+
     //TODO: for sequences, should the nested required be ignored?
     "map Option[Seq[T]] to item type" >> {
       mapParam(Parameter("aField", "Option[Seq[String]]", None, None)) === GenSwaggerParameter(

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -17,7 +17,7 @@ case class Keeper(internalFieldName1: String, internalFieldName2: Int)
 case class PolymorphicContainer(item: PolymorphicItem)
 trait PolymorphicItem
 
-case class JavaEnumContainer(status: SampleJavaEnum)
+case class EnumContainer(javaEnum: SampleJavaEnum, scalaEnum: SampleScalaEnum.SampleScalaEnum)
 
 case class AllOptional(a: Option[String], b: Option[String])
 
@@ -101,7 +101,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     lazy val teacherJson = (definitionsJson \ "com.iheart.playSwagger.Teacher").asOpt[JsObject]
     lazy val polymorphicContainerJson = (definitionsJson \ "com.iheart.playSwagger.PolymorphicContainer").asOpt[JsObject]
     lazy val polymorphicItemJson = (definitionsJson \ "com.iheart.playSwagger.PolymorphicItem").asOpt[JsObject]
-    lazy val javaEnumContainerJson = (definitionsJson \ "com.iheart.playSwagger.JavaEnumContainer").asOpt[JsObject]
+    lazy val enumContainerJson = (definitionsJson \ "com.iheart.playSwagger.EnumContainer").asOpt[JsObject]
     lazy val overriddenDictTypeJson = (definitionsJson \ "com.iheart.playSwagger.DictType").as[JsObject]
 
     def parametersOf(json: JsValue): Seq[JsValue] = {
@@ -168,8 +168,13 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     }
 
     "read java enum with container" >> {
-      javaEnumContainerJson must beSome[JsObject]
-      (javaEnumContainerJson.get \ "properties" \ "status" \ "enum").asOpt[Seq[String]] === Some(Seq("DISABLED", "ACTIVE"))
+      enumContainerJson must beSome[JsObject]
+      (enumContainerJson.get \ "properties" \ "javaEnum" \ "enum").asOpt[Seq[String]] === Some(Seq("DISABLED", "ACTIVE"))
+    }
+
+    "read scala enum with container" >> {
+      enumContainerJson must beSome[JsObject]
+      (enumContainerJson.get \ "properties" \ "scalaEnum" \ "enum").asOpt[Seq[String]] === Some(Seq("One", "Two"))
     }
 
     "definition property have no name" >> {


### PR DESCRIPTION
Hey @kailuowang 
finally found some time to start integrating the plugin :)
Here's a PR to add support for scala enumerations as well. Hope that's fine...

Btw, really like  the `swagger-custom-mappings.yml`!

Best, Moritz