### PR TITLE
add operation ids

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -376,7 +376,11 @@ final case class SwaggerSpecGenerator(
 
     val parameterJson = if (mergedParams.value.nonEmpty) Json.obj("parameters" → mergedParams) else Json.obj()
 
-    val rawPathJson = tag.fold(Json.obj()) { t ⇒
+    val operationId = Json.obj(
+      "operationId" → route.call.method
+    )
+
+    val rawPathJson = operationId ++ tag.fold(Json.obj()) { t ⇒
       Json.obj("tags" → List(t))
     } ++ jsonFromComment.getOrElse(Json.obj()) ++ parameterJson
 

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -388,6 +388,10 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
       required.value must contain(JsString("keeper"))
     }
 
+    "add operation ids" >> {
+      (addTrackJson \ "operationId").as[String] ==== "addPlayedTracks"
+    }
+
     // TODO: routes order
 
   }

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
@@ -23,6 +23,7 @@ TaskKey[Unit]("check") := {
       |   "paths":{
       |      "/tracks/{trackId}":{
       |         "get":{
+      |           "operationId":"versioned",
       |            "tags":[
       |               "${swaggerRoutesFile.value}"
       |            ],


### PR DESCRIPTION
To enable code generation, swagger provides the 'operationId' field. This is expected to be unique, as the documentation for this field states: 

> Unique string used to identify the operation. The id MUST be unique among all operations described in the API. Tools and libraries MAY use the operationId to uniquely identify an operation, therefore, it is recommended to follow common programming naming conventions.

However, according to some comments here https://github.com/OAI/OpenAPI-Specification/issues/381, this is only meant to be unique per endpoint, which should work for most use cases.

However, since I'm only using the method name this would cause issues if two controllers are used with the same method in the same routes file: 

```
# for now, PUT and POST have the same behavior
PUT    /users    controllers.Users.add
POST /users    controllers.Users.add
```

We may want validation for a use case like that. We could also allow customization via a function passed to the generator like `operationId: Route => String`