### PR TITLE
Fix Custom Type Overrides in Optional Parameters

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -64,11 +64,8 @@ object SwaggerParameterMapper {
       GenSwaggerParameter(parameter.name, referenceType = Some(referenceType))
 
     def optionalParam(optionalTpe: String) = {
-      val param = if (isReference(optionalTpe))
-        referenceParam(optionalTpe)
-      else
-        mapParam(parameter.copy(typeName = optionalTpe), modelQualifier = modelQualifier, customMappings = customMappings)
-      param.update(required = false, default = defaultValueO)
+      val asRequired = mapParam(parameter.copy(typeName = optionalTpe), modelQualifier = modelQualifier, customMappings = customMappings)
+      asRequired.update(required = false, default = asRequired.default)
     }
 
     def updateGenParam(param: SwaggerParameter)(update: GenSwaggerParameter ⇒ GenSwaggerParameter): SwaggerParameter = param match {


### PR DESCRIPTION
Replaces the behavior of `Option[A]` wrapped parameters in the SwaggerParameterMapper to always perform a full recursive pass as non-optional before changing the `required` flag on the field, even if the field is a `$ref` type.

This appears to fix https://github.com/iheartradio/play-swagger/issues/139 and didn't trigger any regressions in tests.