### PR TITLE
Fixing generation of string default parameters

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -35,7 +35,11 @@ object SwaggerParameterMapper {
           case ci"Double" | ci"Float" | ci"BigDecimal" ⇒ JsNumber(value.toDouble)
           case ci"Boolean"                             ⇒ JsBoolean(value.toBoolean)
           case ci"String" ⇒ {
-            val noquotes: String = "^(?:\"|\"\"\")?(.*?)(?:\"|\"\"\")?$".r.replaceAllIn(value, "$1")
+            val noquotes = value match {
+              case c if c.startsWith("\"\"\"") && c.endsWith("\"\"\"") ⇒ c.substring(3, c.length - 3)
+              case c if c.startsWith("\"") && c.endsWith("\"") ⇒ c.substring(1, c.length - 1)
+              case c ⇒ c
+            }
             JsString(noquotes)
           }
           case _ ⇒ JsString(value)

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -34,7 +34,11 @@ object SwaggerParameterMapper {
           case ci"Int" | ci"Long"                      ⇒ JsNumber(value.toLong)
           case ci"Double" | ci"Float" | ci"BigDecimal" ⇒ JsNumber(value.toDouble)
           case ci"Boolean"                             ⇒ JsBoolean(value.toBoolean)
-          case _                                       ⇒ JsString(value)
+          case ci"String" ⇒ {
+            val noquotes: String = "^(?:\"|\"\"\")?(.*?)(?:\"|\"\"\")?$".r.replaceAllIn(value, "$1")
+            JsString(noquotes)
+          }
+          case _ ⇒ JsString(value)
         }
       }
     }

--- a/core/src/test/resources/students.routes
+++ b/core/src/test/resources/students.routes
@@ -6,6 +6,7 @@
 ###
 GET     /:name    com.iheart.controllers.Students.get(name)
 
-PUT     /defaultValueParam          com.iheart.controllers.DefaultValueParam.put(aFlag:Boolean ?= true)
-PUT     /defaultValueParamString    com.iheart.controllers.DefaultValueParam.put(strFlag:String ?= "defaultValue")
+PUT     /defaultValueParam           com.iheart.controllers.DefaultValueParam.put(aFlag:Boolean ?= true)
+PUT     /defaultValueParamString     com.iheart.controllers.DefaultValueParam.put(strFlag:String ?= "defaultValue")
+PUT     /defaultValueParamString3    com.iheart.controllers.DefaultValueParam.put(strFlag:String ?= """defaultValue with triple quotes""")
 

--- a/core/src/test/resources/students.routes
+++ b/core/src/test/resources/students.routes
@@ -6,5 +6,6 @@
 ###
 GET     /:name    com.iheart.controllers.Students.get(name)
 
-PUT     /defaultValueParam   com.iheart.controllers.DefaultValueParam.put(aFlag:Boolean ?= true)
+PUT     /defaultValueParam          com.iheart.controllers.DefaultValueParam.put(aFlag:Boolean ?= true)
+PUT     /defaultValueParamString    com.iheart.controllers.DefaultValueParam.put(strFlag:String ?= "defaultValue")
 

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -118,8 +118,24 @@ class SwaggerParameterMapperSpec extends Specification {
       parameter.asInstanceOf[GenSwaggerParameter].format must beNone
     }
 
-    "map default field to to content without quotes for String" >> {
+    "map default value to content without quotes when provided with string without quotes" >> {
       mapParam(Parameter("strField", "String", None, Some("defaultValue"))) === GenSwaggerParameter(
+        name = "strField",
+        `type` = Option("string"),
+        required = false,
+        default = Option(JsString("defaultValue"))
+      )
+    }
+    "map default value to content without quotes when provided with string with simple quotes" >> {
+      mapParam(Parameter("strField", "String", None, Some("\"defaultValue\""))) === GenSwaggerParameter(
+        name = "strField",
+        `type` = Option("string"),
+        required = false,
+        default = Option(JsString("defaultValue"))
+      )
+    }
+    "map default value to content without quotes when provided with string with triple quotes" >> {
+      mapParam(Parameter("strField", "String", None, Some("\"\"\"defaultValue\"\"\""))) === GenSwaggerParameter(
         name = "strField",
         `type` = Option("string"),
         required = false,

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -117,6 +117,15 @@ class SwaggerParameterMapperSpec extends Specification {
       parameter.asInstanceOf[GenSwaggerParameter].`type` must beSome("string")
       parameter.asInstanceOf[GenSwaggerParameter].format must beNone
     }
+
+    "map default field to to content without quotes for String" >> {
+      mapParam(Parameter("strField", "String", None, Some("defaultValue"))) === GenSwaggerParameter(
+        name = "strField",
+        `type` = Option("string"),
+        required = false,
+        default = Option(JsString("defaultValue"))
+      )
+    }
   }
 }
 

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -289,6 +289,28 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
       }
     }
 
+    "parse param with default string value as optional field" >> {
+      val endPointJson = (pathJson \ "/api/students/defaultValueParamString" \ "put").asOpt[JsObject]
+      endPointJson must beSome[JsObject]
+
+      val paramJson: JsValue = parametersOf(endPointJson.get).head
+
+      (paramJson \ "name").as[String] === "strFlag"
+
+      "set required as false" >> {
+        (paramJson \ "required").as[Boolean] === false
+      }
+
+      "set in as query" >> {
+        (paramJson \ "in").as[String] === "query"
+      }
+
+      "set default value" >> {
+
+        (paramJson \ "default").as[String] === "defaultValue"
+      }
+    }
+
     "should contain schemas in responses" >> {
       (postBodyJson \ "responses" \ "200" \ "schema" \ "$ref").asOpt[String] === Some("#/definitions/com.iheart.playSwagger.FooWithSeq2")
     }

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -289,6 +289,27 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
       }
     }
 
+    "parse param with default triple quoted string value as optional field" >> {
+      val endPointJson = (pathJson \ "/api/students/defaultValueParamString3" \ "put").asOpt[JsObject]
+      endPointJson must beSome[JsObject]
+
+      val paramJson: JsValue = parametersOf(endPointJson.get).head
+
+      (paramJson \ "name").as[String] === "strFlag"
+
+      "set required as false" >> {
+        (paramJson \ "required").as[Boolean] === false
+      }
+
+      "set in as query" >> {
+        (paramJson \ "in").as[String] === "query"
+      }
+
+      "set default value" >> {
+        (paramJson \ "default").as[String] === """defaultValue with triple quotes"""
+      }
+    }
+
     "parse param with default string value as optional field" >> {
       val endPointJson = (pathJson \ "/api/students/defaultValueParamString" \ "put").asOpt[JsObject]
       endPointJson must beSome[JsObject]


### PR DESCRIPTION
Fixes #134 
The parameter mapper from default value string seems a bit hacky but
it seems to be the right way to handle it, I talked with some 
maintainers on playframework and strangely they always get this value
as literal, which means there's no nice way to convert this to the
correct parameter type.