### PR TITLE
Maintain route file ordering in SwaggerSpecGenerator

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -276,9 +276,14 @@ final case class SwaggerSpecGenerator(
 
   private def paths(routes: Seq[Route], prefix: String, tag: Option[Tag]): JsObject = {
     JsObject {
-      routes.flatMap(endPointEntry(_, prefix, tag))
-        .groupBy(_._1) // Routes grouped by path
-        .mapValues(_.map(_._2).reduce(_ deepMerge _))
+      val endPointEntries = routes.flatMap(route ⇒ endPointEntry(route, prefix, tag))
+
+      val zgbp = endPointEntries.zipWithIndex.groupBy(_._1._1)
+      import collection.mutable.LinkedHashMap
+      val lhm = LinkedHashMap(zgbp.toSeq sortBy (_._2.head._2): _*)
+      val gbp2 = lhm mapValues (_ map (_._1)) toSeq
+
+      gbp2.toSeq.map(x ⇒ (x._1, x._2.map(_._2).reduce(_ deepMerge _)))
     }
   }
 

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -278,6 +278,7 @@ final case class SwaggerSpecGenerator(
     JsObject {
       val endPointEntries = routes.flatMap(route ⇒ endPointEntry(route, prefix, tag))
 
+      // maintain the routes order as per the original routing file
       val zgbp = endPointEntries.zipWithIndex.groupBy(_._1._1)
       import collection.mutable.LinkedHashMap
       val lhm = LinkedHashMap(zgbp.toSeq sortBy (_._2.head._2): _*)

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -435,7 +435,29 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
       (addTrackJson \ "operationId").as[String] ==== "addPlayedTracks"
     }
 
-    // TODO: routes order
+    "should maintain route file order" >> {
+      // use students routes
+
+      val pathJsonObj = pathJson.as[JsObject]
+      val fieldKeys: Seq[String] = pathJsonObj.fields.map(_._1)
+      val fieldsWithIndexMap = fieldKeys.zipWithIndex.toMap
+
+      val first = fieldsWithIndexMap.get("/api/students/{name}")
+      val second = fieldsWithIndexMap.get("/api/students/defaultValueParam")
+      val third = fieldsWithIndexMap.get("/api/students/defaultValueParamString")
+      val fourth = fieldsWithIndexMap.get("/api/students/defaultValueParamString3")
+
+      // all paths must be retrieved
+      first must beSome[Int]
+      second must beSome[Int]
+      third must beSome[Int]
+      fourth must beSome[Int]
+
+      // must be in exact order with nothing inbetween 
+      second.get - first.get === 1
+      third.get - second.get === 1
+      fourth.get - third.get === 1
+    }
 
   }
 


### PR DESCRIPTION
Test passes, but isn't particularly pleasing to the eye;)  

Uses the student routes as the test case - hope that's good enough.