### PR TITLE
Update dependencies for Play 2.6 RC2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val play = "2.6.0-RC1"
-    val playJson = "2.6.0-RC1"
+    val play = "2.6.0-RC2"
+    val playJson = "2.6.0-RC2"
     val specs2 = "3.8.9"
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,8 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val play = "2.6.0-M5"
+    val play = "2.6.0-RC1"
+    val playJson = "2.6.0-RC1"
     val specs2 = "3.8.9"
   }
 
@@ -15,11 +16,11 @@ object Dependencies {
   )
 
   val playJson = Seq(
-    "com.typesafe.play" %% "play-json" % Versions.play % "provided"
+    "com.typesafe.play" %% "play-json" % Versions.playJson % "provided"
   )
 
   val yaml = Seq(
-    "org.yaml" % "snakeyaml" % "1.16"
+    "org.yaml" % "snakeyaml" % "1.18"
   )
 
   val test = Seq(

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/project/plugins.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/project/plugins.sbt
@@ -1,7 +1,7 @@
 logLevel in update := sbt.Level.Warn
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.6")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0-RC1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0-RC2")
 
 {
   val pluginVersion = System.getProperty("plugin.version")

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/project/plugins.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/project/plugins.sbt
@@ -1,7 +1,7 @@
 logLevel in update := sbt.Level.Warn
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.6")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0-M5")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0-RC1")
 
 {
   val pluginVersion = System.getProperty("plugin.version")


### PR DESCRIPTION
Since there is a Play 2.6.0 RC-1 and Json library is now a separate project a minor change is required.