### PR TITLE
Fix tests so they work on Windows (as well as linux).

### DIFF
--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
@@ -34,7 +34,7 @@ TaskKey[Unit]("check") := {
       |            "summary":"Get the track metadata",
       |            "responses":{
       |               "200":{
-      |                  "summary": "$pathVal",
+      |                  "summary": "${pathVal.replace("\\", "\\\\")}",
       |                  "schema":{
       |                     "$$ref":"#/definitions/namespace2.Track"
       |                  }
@@ -148,4 +148,28 @@ TaskKey[Unit]("check") := {
          $left
        """.stripMargin)
   }
+}
+
+TaskKey[Unit]("unzip1") := {
+  val from = new File("target/scala-2.11/app_2.11-0.1-SNAPSHOT.jar")
+  val to = new File("target/jar")
+  IO.unzip(from, to)
+}
+
+TaskKey[Unit]("unzip2") := {
+  val from = new File("target/universal/app-0.1-SNAPSHOT.zip")
+  val to = new File("target/dist")
+  IO.unzip(from, to)
+}
+
+TaskKey[Unit]("unzip3") := {
+  val from = new File("target/dist/app-0.1-SNAPSHOT/lib/app.app-0.1-SNAPSHOT-sans-externalized.jar")
+  val to = new File("target/dist/jar")
+  IO.unzip(from, to)
+}
+
+TaskKey[Unit]("unzip4") := {
+  val from = new File("target/universal/stage/lib/app.app-0.1-SNAPSHOT-sans-externalized.jar")
+  val to = new File("target/jar")
+  IO.unzip(from, to)
 }

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/test
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/test
@@ -6,13 +6,13 @@
 
 
 $ absent target/jar/public/swagger.json
-$ exec unzip -q target/scala-2.11/app_2.11-0.1-SNAPSHOT.jar -d target/jar
+> unzip1
 $ exists target/jar/public/swagger.json
 
 
 $ absent target/dist/jar/public/swagger.json
-$ exec unzip -q target/universal/app-0.1-SNAPSHOT.zip -d target/dist
-$ exec unzip -q target/dist/app-0.1-SNAPSHOT/lib/app.app-0.1-SNAPSHOT-sans-externalized.jar -d target/dist/jar
+> unzip2
+> unzip3
 $ exists target/dist/jar/public/swagger.json
 
 
@@ -20,6 +20,6 @@ $ exists target/dist/jar/public/swagger.json
 > stage
 
 $ absent target/jar/public/swagger.json
-$ exec unzip -q target/universal/stage/lib/app.app-0.1-SNAPSHOT-sans-externalized.jar -d target/jar
+> unzip4
 $ exists target/jar/public/swagger.json
 


### PR DESCRIPTION
I tried to run the tests on windows, but they failed due to some linux specific things in them:
- the pathVal would fail with this error:
`[info] [error] DIFF >>>>>>>>>>>
[info] [error] Result >             "summary":"C:\\ProgramData\\Oracle\\Java\\javapath;C:\\WINDOWS\\system32;C:\\WINDOWS;C:\\WINDOWS\\System32\\Wbem;C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\;
[info] [error] Expect <             "summary":"C:\\rogramData\\racle\\ava\\avapath;C:\\INDOWS\\ystem32;C:\\INDOWS;C:\\INDOWS\\ystem32\\bem;C:\\INDOWS\\ystem32\\indowsPowerShell\\1.0\\C:\\pps\nodejs;`
The first letter after every slash would be incorrectly seen as a control character. (linux paths don't have this problem, since they contain forward slashes).

- Next, in the plugin tests the linux specific 'unzip' command was used. Unzipping is now done in sbt, which is windows compatible.