### PR TITLE
Updated play2.6 branch to 2.6.0 (final) + migrated and fixed example branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ You can find the setup in the example project as well.
   
 
 #### Step 1
+For play2.6 add Swagger sbt plugin dependency to your plugins.sbt
+```scala
+addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.6.1-PLAY2.6")
+```
+
 For play2.5 add Swagger sbt plugin dependency to your plugins.sbt (see [the releases tab](https://github.com/iheartradio/play-swagger/releases) for the latest versions)
 
 ```scala

--- a/example/app/controllers/AsyncController.scala
+++ b/example/app/controllers/AsyncController.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
  * asynchronous code.
  */
 @Singleton
-class AsyncController @Inject() (actorSystem: ActorSystem)(implicit exec: ExecutionContext) extends Controller {
+class AsyncController @Inject() (actorSystem: ActorSystem, components: ControllerComponents)(implicit exec: ExecutionContext) extends AbstractController(components) {
   implicit val fmt = Json.format[Message]
   /**
    * Create an Action that returns a plain text message after a delay

--- a/example/app/controllers/HomeController.scala
+++ b/example/app/controllers/HomeController.scala
@@ -9,7 +9,7 @@ import play.api.mvc._
  * application's home page.
  */
 @Singleton
-class HomeController @Inject() extends Controller {
+class HomeController @Inject() (components: ControllerComponents) extends AbstractController(components) {
 
   /**
    * Create an Action to render an HTML page with a welcome message.

--- a/example/app/controllers/math/CountController.scala
+++ b/example/app/controllers/math/CountController.scala
@@ -12,7 +12,7 @@ import services.Counter
  * object is injected by the Guice dependency injection system.
  */
 @Singleton
-class CountController @Inject() (counter: Counter) extends Controller {
+class CountController @Inject() (counter: Counter, components: ControllerComponents) extends AbstractController(components) {
 
   /**
    * Create an action that responds with the [[Counter]]'s current

--- a/example/app/views/index.scala.html
+++ b/example/app/views/index.scala.html
@@ -15,6 +15,6 @@
      * Get an `Html` object by calling the built-in Play welcome
      * template and passing a `String` message.
      *@
-    @play20.welcome(message, style = "Scala")
+    @message
 
 }

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -10,7 +10,8 @@ libraryDependencies ++= Seq(
   jdbc,
   cache,
   ws,
-  "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Test,
+  guice,
+  "org.scalatestplus.play" %% "scalatestplus-play" % "3.0.0" % Test,
   "org.webjars" % "swagger-ui" % "2.2.0"  //play-swagger ui integration
 )
 

--- a/example/conf/application.conf
+++ b/example/conf/application.conf
@@ -41,7 +41,7 @@ akka {
 # The secret key is used to sign Play's session cookie.
 # This must be changed for production, but we don't recommend you change it in this file.
 # The following is for the convenience of Play-Swagger development, don't use it for your project!
-play.crypto.secret = "QCY?tAnfk?aZ?iwrNwnxIlR6CTf:G3gf:90Latabg@5241AB`R5W:1uDFN];Ik@n"
+play.http.secret.key = "QCY?tAnfk?aZ?iwrNwnxIlR6CTf:G3gf:90Latabg@5241AB`R5W:1uDFN];Ik@n"
 
 
 ## Modules

--- a/example/project/plugins.sbt
+++ b/example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0-M5")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0")
 
 // web plugins
 
@@ -18,6 +18,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.1.0")
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.2")
 
 // play swagger plugin
-addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.6.1-PLAY2.6-M5")
+addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.6.1-PLAY2.6")
 
 

--- a/example/test/ApplicationSpec.scala
+++ b/example/test/ApplicationSpec.scala
@@ -1,13 +1,14 @@
 import org.scalatestplus.play._
 import play.api.test._
 import play.api.test.Helpers._
+import org.scalatestplus.play.guice.GuiceOneAppPerTest
 
 /**
  * Add your spec here.
  * You can mock out a whole application including requests, plugins etc.
  * For more information, consult the wiki.
  */
-class ApplicationSpec extends PlaySpec with OneAppPerTest {
+class ApplicationSpec extends PlaySpec with GuiceOneAppPerTest {
 
   "Routes" should {
 
@@ -32,9 +33,9 @@ class ApplicationSpec extends PlaySpec with OneAppPerTest {
   "CountController" should {
 
     "return an increasing count" in {
-      contentAsString(route(app, FakeRequest(GET, "/count")).get) mustBe "0"
-      contentAsString(route(app, FakeRequest(GET, "/count")).get) mustBe "1"
-      contentAsString(route(app, FakeRequest(GET, "/count")).get) mustBe "2"
+      contentAsString(route(app, FakeRequest(GET, "/math")).get) mustBe "0"
+      contentAsString(route(app, FakeRequest(GET, "/math")).get) mustBe "1"
+      contentAsString(route(app, FakeRequest(GET, "/math")).get) mustBe "2"
     }
 
   }

--- a/example/test/IntegrationSpec.scala
+++ b/example/test/IntegrationSpec.scala
@@ -1,12 +1,13 @@
 import org.scalatestplus.play._
 import play.api.test._
 import play.api.test.Helpers._
+import org.scalatestplus.play.guice.GuiceOneServerPerTest
 
 /**
  * add your integration spec here.
  * An integration test will fire up a whole play application in a real (or headless) browser
  */
-class IntegrationSpec extends PlaySpec with OneServerPerTest with OneBrowserPerTest with HtmlUnitFactory {
+class IntegrationSpec extends PlaySpec with GuiceOneServerPerTest with OneBrowserPerTest with HtmlUnitFactory {
 
   "Application" should {
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val play = "2.6.0-RC2"
-    val playJson = "2.6.0-RC2"
+    val play = "2.6.0"
+    val playJson = "2.6.0"
     val specs2 = "3.8.9"
   }
 

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
@@ -34,7 +34,7 @@ TaskKey[Unit]("check") := {
       |            "summary":"Get the track metadata",
       |            "responses":{
       |               "200":{
-      |                  "summary": "$pathVal",
+      |                  "summary": "${pathVal.replace("\\", "\\\\")}",
       |                  "schema":{
       |                     "$$ref":"#/definitions/namespace2.Track"
       |                  }
@@ -148,4 +148,28 @@ TaskKey[Unit]("check") := {
          $left
        """.stripMargin)
   }
+}
+
+TaskKey[Unit]("unzip1") := {
+  val from = new File("target/scala-2.11/app_2.11-0.1-SNAPSHOT.jar")
+  val to = new File("target/jar")
+  IO.unzip(from, to)
+}
+
+TaskKey[Unit]("unzip2") := {
+  val from = new File("target/universal/app-0.1-SNAPSHOT.zip")
+  val to = new File("target/dist")
+  IO.unzip(from, to)
+}
+
+TaskKey[Unit]("unzip3") := {
+  val from = new File("target/dist/app-0.1-SNAPSHOT/lib/app.app-0.1-SNAPSHOT-sans-externalized.jar")
+  val to = new File("target/dist/jar")
+  IO.unzip(from, to)
+}
+
+TaskKey[Unit]("unzip4") := {
+  val from = new File("target/universal/stage/lib/app.app-0.1-SNAPSHOT-sans-externalized.jar")
+  val to = new File("target/jar")
+  IO.unzip(from, to)
 }

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
@@ -151,7 +151,7 @@ TaskKey[Unit]("check") := {
 }
 
 TaskKey[Unit]("unzip1") := {
-  val from = new File("target/scala-2.11/app_2.11-0.1-SNAPSHOT.jar")
+  val from = new File("target/scala-2.12/app_2.12-0.1-SNAPSHOT.jar")
   val to = new File("target/jar")
   IO.unzip(from, to)
 }

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/project/plugins.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/project/plugins.sbt
@@ -1,7 +1,7 @@
 logLevel in update := sbt.Level.Warn
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.6")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0-RC2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.0")
 
 {
   val pluginVersion = System.getProperty("plugin.version")

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/test
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/test
@@ -6,13 +6,13 @@
 
 
 $ absent target/jar/public/swagger.json
-$ exec unzip -q target/scala-2.12/app_2.12-0.1-SNAPSHOT.jar -d target/jar
+> unzip1
 $ exists target/jar/public/swagger.json
 
 
 $ absent target/dist/jar/public/swagger.json
-$ exec unzip -q target/universal/app-0.1-SNAPSHOT.zip -d target/dist
-$ exec unzip -q target/dist/app-0.1-SNAPSHOT/lib/app.app-0.1-SNAPSHOT-sans-externalized.jar -d target/dist/jar
+> unzip2
+> unzip3
 $ exists target/dist/jar/public/swagger.json
 
 
@@ -20,6 +20,6 @@ $ exists target/dist/jar/public/swagger.json
 > stage
 
 $ absent target/jar/public/swagger.json
-$ exec unzip -q target/universal/stage/lib/app.app-0.1-SNAPSHOT-sans-externalized.jar -d target/jar
+> unzip4
 $ exists target/jar/public/swagger.json
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.1"
+version in ThisBuild := "0.6.1-PLAY2.6"


### PR DESCRIPTION
- All references to M5 or RC2 versions are now to the release version of Play 2.6.0
- Pulled and merged the newest version of the master
- Pulled the windows test fix  #166 
- Migrated the example project using the 2.6.x migration guide (https://www.playframework.com/documentation/2.6.x/Migration26)
- Fixed all the unit tests
- Should fix #162 