### PR TITLE
add cross build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ cache:
 
 script:
   - sbt scripted
-  - sbt ';+clean;coverage;+test'
+  - sbt ';+playSwagger/clean;playSwagger/coverage;+playSwagger/test'
 after_success:
-  - sbt ';+coverageReport;+coveralls'
+  - sbt ';+playSwagger/coverageReport;+playSwagger/coveralls'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ cache:
 
 script:
   - sbt scripted
-  - sbt ';+playSwagger/clean;playSwagger/coverage;+playSwagger/test'
+  - sbt ';+playSwagger/clean;coverage;+playSwagger/test'
 after_success:
   - sbt ';+playSwagger/coverageReport;+playSwagger/coveralls'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
    - docker
 
 scala:
-   - 2.11.7
+   - 2.11.11
    
 jdk:
    - oraclejdk8
@@ -18,7 +18,7 @@ cache:
   - $HOME/.sbt/boot/
 
 script:
-  - sbt clean sbtPlaySwagger/test
-  - sbt ';project playSwagger;clean;coverage;test'
+  - sbt scripted
+  - sbt ';+clean;coverage;+test'
 after_success:
-  - sbt ';project playSwagger;coverageReport;coveralls'
+  - sbt ';+coverageReport;+coveralls'

--- a/build.sbt
+++ b/build.sbt
@@ -11,34 +11,42 @@ lazy val noPublishSettings = Seq(
 )
 
 lazy val root = project.in(file("."))
+  .enablePlugins(CrossPerProjectPlugin)
   .aggregate(playSwagger, sbtPlaySwagger)
-  .settings(sourcesInBase := false)
-  .settings(noPublishSettings:_*)
+  .settings(
+    noPublishSettings,
+    sourcesInBase := false,
+    scalaVersion := "2.11.11",
+    releaseCrossBuild := false
+  )
 
 lazy val playSwagger = project.in(file("core"))
+  .enablePlugins(CrossPerProjectPlugin)
   .settings(Publish.coreSettings ++ Format.settings ++ Testing.settings)
   .settings(
     name := "play-swagger",
-    libraryDependencies ++= Dependencies.playTest ++
-      Dependencies.playRoutesCompiler ++
-      Dependencies.playJson ++
+    libraryDependencies ++= Dependencies.playTest.value ++
+      Dependencies.playRoutesCompiler.value ++
+      Dependencies.playJson.value ++
       Dependencies.test ++
       Dependencies.yaml,
-    scalaVersion := "2.11.7"
+    scalaVersion := "2.11.11",
+    crossScalaVersions := Seq("2.11.11", "2.12.2")
   )
 
 lazy val sbtPlaySwagger = project.in(file("sbtPlugin"))
+  .enablePlugins(CrossPerProjectPlugin)
+  .enablePlugins(BuildInfoPlugin)
   .settings(Publish.sbtPluginSettings ++ Format.settings ++ ScriptedTesting.settings)
   .settings(
     addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.6" % Provided),
-    addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.3.0" % Provided))
-  .enablePlugins(BuildInfoPlugin)
-  .settings(
+    addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.3.0" % Provided),
     buildInfoKeys := Seq[BuildInfoKey](name, version),
     buildInfoPackage := "com.iheart.playSwagger",
     name := "sbt-play-swagger",
     description := "sbt plugin for play swagger spec generation",
     sbtPlugin := true,
     scalaVersion := "2.10.6",
+    crossScalaVersions := Seq("2.10.6"),
     scripted := scripted.dependsOn(publishLocal in playSwagger).evaluated
   )

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, SwaggerPlugin) //enable plugin
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.11"
 
 libraryDependencies ++= Seq(
   jdbc,

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -4,13 +4,13 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, SwaggerPlugin) //enable plugin
 
-scalaVersion := "2.11.11"
+scalaVersion := "2.12.2"
 
 libraryDependencies ++= Seq(
   jdbc,
   cache,
   ws,
-  "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Test,
+  "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.0" % Test,
   "org.webjars" % "swagger-ui" % "2.2.0"  //play-swagger ui integration
 )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,22 +1,34 @@
 import sbt._
+import Keys._
 
 object Dependencies {
   object Versions {
-    val play = "2.5.14"
     val specs2 = "3.8.9"
+    val play = Def.setting {
+      scalaBinaryVersion.value match {
+        case "2.12" => "2.6.1"
+        case _ => "2.5.14"
+      }
+    }
   }
 
-  val playTest = Seq(
-    "com.typesafe.play" %% "play-test" % Versions.play % Test
-  )
+  val playTest = Def.setting {
+    Seq(
+      "com.typesafe.play" %% "play-test" % Versions.play.value % Test
+    )
+  }
 
-  val playRoutesCompiler = Seq(
-    "com.typesafe.play" %% "routes-compiler" % Versions.play
-  )
+  val playRoutesCompiler = Def.setting {
+    Seq(
+      "com.typesafe.play" %% "routes-compiler" % Versions.play.value
+    )
+  }
 
-  val playJson = Seq(
-    "com.typesafe.play" %% "play-json" % Versions.play % "provided"
-  )
+  val playJson = Def.setting {
+    Seq(
+      "com.typesafe.play" %% "play-json" % Versions.play.value % "provided"
+    )
+  }
 
   val yaml = Seq(
     "org.yaml" % "snakeyaml" % "1.16"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
@@ -8,7 +8,7 @@ enablePlugins(PlayScala, SwaggerPlugin)
 
 name := "app"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.11"
 
 swaggerDomainNameSpaces := Seq("namespace1", "namespace2")
 


### PR DESCRIPTION
Because this project houses an sbt plugin, which is restricted to 2.10, making `crossScalaVersions` work required adding sbt-doge. `sbt-doge` has been merged into sbt 1.0, so this should be temporary.