### PR TITLE
Add capability of mapping types to some optional type…

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/Domain.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/Domain.scala
@@ -52,7 +52,8 @@ object Domain {
   case class CustomTypeMapping(
     `type`:          String,
     specAsParameter: List[JsObject]   = Nil,
-    specAsProperty:  Option[JsObject] = None
+    specAsProperty:  Option[JsObject] = None,
+    required:        Boolean          = true
   )
 }
 

--- a/core/src/main/scala/com/iheart/playSwagger/Domain.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/Domain.scala
@@ -1,6 +1,6 @@
 package com.iheart.playSwagger
 
-import play.api.libs.json.{JsObject, JsValue}
+import play.api.libs.json.{JsObject, JsPath, JsValue, Reads}
 import play.twirl.api.TemplateMagic.Default
 
 object Domain {
@@ -55,5 +55,15 @@ object Domain {
     specAsProperty:  Option[JsObject] = None,
     required:        Boolean          = true
   )
+
+  object CustomTypeMapping {
+    import play.api.libs.functional.syntax._
+    implicit val csmFormat: Reads[CustomTypeMapping] = (
+      (JsPath \ 'type).read[String] and
+      (JsPath \ 'specAsParameter).read[List[JsObject]] and
+      (JsPath \ 'specAsProperty).readNullable[JsObject] and
+      ((JsPath \ 'required).read[Boolean] orElse Reads.pure(true))
+    )(CustomTypeMapping.apply _)
+  }
 }
 

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -122,7 +122,7 @@ object SwaggerParameterMapper {
             mapping.specAsParameter,
             mapping.specAsProperty,
             default = defaultValueO,
-            required = defaultValueO.isEmpty
+            required = defaultValueO.isEmpty && mapping.required
           )
       }
       mf

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -236,12 +236,6 @@ final case class SwaggerSpecGenerator(
   private lazy val defaultBase: JsObject = readYmlOrJson[JsObject](baseSpecFileName).getOrElse(throw MissingBaseSpecException)
 
   private lazy val customMappings: CustomMappings = {
-    implicit val csmFormat: Reads[CustomTypeMapping] = (
-      (JsPath \ 'type).read[String] and
-      (JsPath \ 'specAsParameter).read[List[JsObject]] and
-      (JsPath \ 'specAsProperty).readNullable[JsObject] and
-      ((JsPath \ 'required).read[Boolean] orElse Reads.pure(true))
-    )(CustomTypeMapping.apply _)
     readYmlOrJson[CustomMappings](customMappingsFileName).getOrElse(Nil)
   }
 

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -236,7 +236,12 @@ final case class SwaggerSpecGenerator(
   private lazy val defaultBase: JsObject = readYmlOrJson[JsObject](baseSpecFileName).getOrElse(throw MissingBaseSpecException)
 
   private lazy val customMappings: CustomMappings = {
-    implicit val csmFormat = Json.reads[CustomTypeMapping]
+    implicit val csmFormat: Reads[CustomTypeMapping] = (
+      (JsPath \ 'type).read[String] and
+      (JsPath \ 'specAsParameter).read[List[JsObject]] and
+      (JsPath \ 'specAsProperty).readNullable[JsObject] and
+      ((JsPath \ 'required).read[Boolean] orElse Reads.pure(true))
+    )(CustomTypeMapping.apply _)
     readYmlOrJson[CustomMappings](customMappingsFileName).getOrElse(Nil)
   }
 

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -57,13 +57,6 @@ class SwaggerSpecGeneratorSpec extends Specification {
   }
 
   "getCfgFile" >> {
-    import play.api.libs.functional.syntax._
-    implicit val csmFormat: Reads[CustomTypeMapping] = (
-      (JsPath \ 'type).read[String] and
-      (JsPath \ 'specAsParameter).read[List[JsObject]] and
-      (JsPath \ 'specAsProperty).readNullable[JsObject] and
-      ((JsPath \ 'required).read[Boolean] orElse Reads.pure(true))
-    )(CustomTypeMapping.apply _)
     "valid swagger-custom-mappings yml" >> {
       val result = gen.readCfgFile[CustomMappings]("swagger-custom-mappings.yml")
       result must beSome[CustomMappings]

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -57,7 +57,13 @@ class SwaggerSpecGeneratorSpec extends Specification {
   }
 
   "getCfgFile" >> {
-    implicit val cmf = Json.reads[CustomTypeMapping]
+    import play.api.libs.functional.syntax._
+    implicit val csmFormat: Reads[CustomTypeMapping] = (
+      (JsPath \ 'type).read[String] and
+      (JsPath \ 'specAsParameter).read[List[JsObject]] and
+      (JsPath \ 'specAsProperty).readNullable[JsObject] and
+      ((JsPath \ 'required).read[Boolean] orElse Reads.pure(true))
+    )(CustomTypeMapping.apply _)
     "valid swagger-custom-mappings yml" >> {
       val result = gen.readCfgFile[CustomMappings]("swagger-custom-mappings.yml")
       result must beSome[CustomMappings]


### PR DESCRIPTION
… in swagger-custom-mappings.yml
I'm looking for some way to map custom type to optional param in documentation(for example i have `option[string with shapeless.tag.tagged]` which i want to map to `option[string]`) but i can't find any way to express it in yml.
So this PR adds optional param required(default true, so it backword compatable) in type mapping.
Example:
```yml
---
  - type: option\[string with shapeless\.tag\.tagged\]
    required: false
    specAsParameter:
      - type: string
```
this maps `option[string with shapeless.tag.tagged]` to `option[string]`

PS: in play 2.6 branch it possible to use:
```scala
 implicit val csmFormat = Json.using[Json.WithDefaultValues].reads[CustomTypeMapping]
```
instead of creating Reads by hand