### PR TITLE
cross building sbt 1.0 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
    - docker
 
 scala:
-   - 2.11.7
+   - 2.11.11
    
 jdk:
    - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ scala:
 jdk:
    - oraclejdk8
 
-
 cache:
   directories:
   - $HOME/.ivy2/cache

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val noPublishSettings = Seq(
 lazy val root = project.in(file("."))
   .aggregate(playSwagger, sbtPlaySwagger)
   .settings(sourcesInBase := false)
-  .settings(noPublishSettings:_*)
+  .settings(noPublishSettings: _*)
 
 lazy val playSwagger = project.in(file("core"))
   .settings(Publish.coreSettings ++ Format.settings ++ Testing.settings)
@@ -38,4 +38,11 @@ lazy val sbtPlaySwagger = project.in(file("sbtPlugin"))
     sbtPlugin := true,
     scalaVersion := "2.10.6",
     scripted := scripted.dependsOn(publishLocal in playSwagger).evaluated
+  ).settings(
+    scalaVersion := "2.12.2",
+    sbtVersion in Global := "1.0.1",
+    scalaCompilerBridgeSource := {
+      val sv = appConfiguration.value.provider.id.version
+      ("org.scala-sbt" % "compiler-interface" % sv % "component").sources
+    }
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,6 @@
 
 organization in ThisBuild := "com.iheart"
 
-resolvers +=  Resolver.bintrayRepo("scalaz", "releases")
-
-
 lazy val noPublishSettings = Seq(
   publish := (),
   publishLocal := (),
@@ -24,14 +21,14 @@ lazy val playSwagger = project.in(file("core"))
       Dependencies.playJson ++
       Dependencies.test ++
       Dependencies.yaml,
-    scalaVersion := "2.11.7"
+    scalaVersion := "2.11.11"
   )
 
 lazy val sbtPlaySwagger = project.in(file("sbtPlugin"))
   .settings(Publish.sbtPluginSettings ++ Format.settings ++ ScriptedTesting.settings)
   .settings(
-    addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.6" % Provided),
-    addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.3.0" % Provided))
+    addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.2" % Provided),
+    addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.4.3" % Provided))
   .enablePlugins(BuildInfoPlugin)
   .settings(
     buildInfoKeys := Seq[BuildInfoKey](name, version),

--- a/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
@@ -1,6 +1,6 @@
 package com.iheart.playSwagger
 
-import com.iheart.playSwagger.Domain.{CustomMappings, SwaggerParameter, GenSwaggerParameter, Definition}
+import com.iheart.playSwagger.Domain.{ CustomMappings, SwaggerParameter, GenSwaggerParameter, Definition }
 import com.iheart.playSwagger.SwaggerParameterMapper.mapParam
 import play.routes.compiler.Parameter
 
@@ -8,8 +8,7 @@ import scala.reflect.runtime.universe._
 
 final case class DefinitionGenerator(
   modelQualifier: DomainModelQualifier = PrefixDomainModelQualifier(),
-  mappings:       CustomMappings       = Nil
-)(implicit cl: ClassLoader) {
+  mappings:       CustomMappings       = Nil)(implicit cl: ClassLoader) {
 
   def dealiasParams(t: Type): Type = {
     appliedType(t.dealias.typeConstructor, t.typeArgs.map { arg ⇒
@@ -33,8 +32,7 @@ final case class DefinitionGenerator(
 
     Definition(
       name = tpe.typeSymbol.fullName,
-      properties = properties
-    )
+      properties = properties)
   }
 
   def definition[T: TypeTag]: Definition = definition(weakTypeOf[T])
@@ -76,9 +74,7 @@ final case class DefinitionGenerator(
 object DefinitionGenerator {
   def apply(
     domainNameSpace:             String,
-    customParameterTypeMappings: CustomMappings
-  )(implicit cl: ClassLoader): DefinitionGenerator =
+    customParameterTypeMappings: CustomMappings)(implicit cl: ClassLoader): DefinitionGenerator =
     DefinitionGenerator(
-      PrefixDomainModelQualifier(domainNameSpace), customParameterTypeMappings
-    )
+      PrefixDomainModelQualifier(domainNameSpace), customParameterTypeMappings)
 }

--- a/core/src/main/scala/com/iheart/playSwagger/Domain.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/Domain.scala
@@ -1,6 +1,6 @@
 package com.iheart.playSwagger
 
-import play.api.libs.json.{JsObject, JsPath, JsValue, Reads}
+import play.api.libs.json.{ JsObject, JsPath, JsValue, Reads }
 import play.twirl.api.TemplateMagic.Default
 
 object Domain {
@@ -10,8 +10,7 @@ object Domain {
   final case class Definition(
     name:        String,
     properties:  Seq[SwaggerParameter],
-    description: Option[String]        = None
-  )
+    description: Option[String]        = None)
 
   sealed trait SwaggerParameter {
     def name: String
@@ -30,8 +29,7 @@ object Domain {
     example:       Option[JsValue]          = None,
     referenceType: Option[String]           = None,
     items:         Option[SwaggerParameter] = None,
-    enum:          Option[Seq[String]]      = None
-  ) extends SwaggerParameter {
+    enum:          Option[Seq[String]]      = None) extends SwaggerParameter {
     def update(_required: Boolean, _default: Option[JsValue]) =
       copy(required = _required, default = _default)
   }
@@ -41,8 +39,7 @@ object Domain {
     specAsParameter: List[JsObject],
     specAsProperty:  Option[JsObject],
     required:        Boolean          = true,
-    default:         Option[JsValue]  = None
-  ) extends SwaggerParameter {
+    default:         Option[JsValue]  = None) extends SwaggerParameter {
     def update(_required: Boolean, _default: Option[JsValue]) =
       copy(required = _required, default = _default)
   }
@@ -53,8 +50,7 @@ object Domain {
     `type`:          String,
     specAsParameter: List[JsObject]   = Nil,
     specAsProperty:  Option[JsObject] = None,
-    required:        Boolean          = true
-  )
+    required:        Boolean          = true)
 
   object CustomTypeMapping {
     import play.api.libs.functional.syntax._
@@ -62,8 +58,7 @@ object Domain {
       (JsPath \ 'type).read[String] and
       (JsPath \ 'specAsParameter).read[List[JsObject]] and
       (JsPath \ 'specAsProperty).readNullable[JsObject] and
-      ((JsPath \ 'required).read[Boolean] orElse Reads.pure(true))
-    )(CustomTypeMapping.apply _)
+      ((JsPath \ 'required).read[Boolean] orElse Reads.pure(true)))(CustomTypeMapping.apply _)
   }
 }
 

--- a/core/src/main/scala/com/iheart/playSwagger/OutputTransformer.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/OutputTransformer.scala
@@ -3,10 +3,10 @@ package com.iheart.playSwagger
 import java.util.regex.Pattern
 
 import com.iheart.playSwagger.OutputTransformer.SimpleOutputTransformer
-import play.api.libs.json.{JsArray, JsString, JsValue, JsObject}
+import play.api.libs.json.{ JsArray, JsString, JsValue, JsObject }
 
 import scala.util.matching.Regex
-import scala.util.{Success, Failure, Try}
+import scala.util.{ Success, Failure, Try }
 
 /** Specialization of a Kleisli function (A => M[B])*/
 trait OutputTransformer extends (JsObject ⇒ Try[JsObject]) {

--- a/core/src/main/scala/com/iheart/playSwagger/ResourceReader.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/ResourceReader.scala
@@ -1,7 +1,7 @@
 package com.iheart.playSwagger
 
-import java.io.{IOException, InputStream}
-import scala.util.{Failure, Try}
+import java.io.{ IOException, InputStream }
+import scala.util.{ Failure, Try }
 import scala.io.Source
 
 object ResourceReader {

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -1,6 +1,6 @@
 package com.iheart.playSwagger
 
-import com.iheart.playSwagger.Domain.{CustomMappings, CustomSwaggerParameter, GenSwaggerParameter, SwaggerParameter}
+import com.iheart.playSwagger.Domain.{ CustomMappings, CustomSwaggerParameter, GenSwaggerParameter, SwaggerParameter }
 import play.api.libs.json._
 import play.routes.compiler.Parameter
 import scala.reflect.runtime.universe
@@ -14,8 +14,7 @@ object SwaggerParameterMapper {
   def mapParam(
     parameter:      Parameter,
     modelQualifier: DomainModelQualifier = PrefixDomainModelQualifier(),
-    customMappings: CustomMappings       = Nil
-  )(implicit cl: ClassLoader): SwaggerParameter = {
+    customMappings: CustomMappings       = Nil)(implicit cl: ClassLoader): SwaggerParameter = {
 
     def removeKnownPrefixes(name: String) = name.replaceAll("(scala.)|(java.lang.)|(math.)|(org.joda.time.)", "")
 
@@ -50,16 +49,14 @@ object SwaggerParameterMapper {
     def genSwaggerParameter(
       tp:     String,
       format: Option[String]      = None,
-      enum:   Option[Seq[String]] = None
-    ) =
+      enum:   Option[Seq[String]] = None) =
       GenSwaggerParameter(
         parameter.name,
         `type` = Some(tp),
         format = format,
         required = defaultValueO.isEmpty,
         default = defaultValueO,
-        enum = enum
-      )
+        enum = enum)
 
     val enumParamMF: MappingFunction = {
       case JavaEnum(enumConstants)  ⇒ genSwaggerParameter("string", enum = Option(enumConstants))
@@ -108,9 +105,7 @@ object SwaggerParameterMapper {
         // http://stackoverflow.com/questions/26206685/how-can-i-describe-complex-json-model-in-swagger
         updateGenParam(generalParamMF("array"))(_.copy(
           items = Some(
-            mapParam(parameter.copy(typeName = collectionItemType(tpe).get), modelQualifier, customMappings)
-          )
-        ))
+            mapParam(parameter.copy(typeName = collectionItemType(tpe).get), modelQualifier, customMappings))))
     }
 
     val customMappingMF: MappingFunction = customMappings.map { mapping ⇒
@@ -122,8 +117,7 @@ object SwaggerParameterMapper {
             mapping.specAsParameter,
             mapping.specAsProperty,
             default = defaultValueO,
-            required = defaultValueO.isEmpty && mapping.required
-          )
+            required = defaultValueO.isEmpty && mapping.required)
       }
       mf
     }.foldLeft[MappingFunction](PartialFunction.empty)(_ orElse _)
@@ -135,8 +129,7 @@ object SwaggerParameterMapper {
       customMappingMF,
       enumParamMF,
       referenceParamMF,
-      generalParamMF
-    ).reduce(_ orElse _)(typeName)
+      generalParamMF).reduce(_ orElse _)(typeName)
 
   }
 

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -11,7 +11,7 @@ import SwaggerParameterMapper.mapParam
 import scala.collection.immutable.ListMap
 import play.routes.compiler._
 
-import scala.util.{Try, Success, Failure}
+import scala.util.{ Try, Success, Failure }
 
 object SwaggerSpecGenerator {
   private val marker = "##"
@@ -28,9 +28,8 @@ object SwaggerSpecGenerator {
 final case class SwaggerSpecGenerator(
   modelQualifier:        DomainModelQualifier   = PrefixDomainModelQualifier(),
   defaultPostBodyFormat: String                 = "application/json",
-  outputTransformers:    Seq[OutputTransformer] = Nil
-)(implicit cl: ClassLoader) {
-  import SwaggerSpecGenerator.{customMappingsFileName, baseSpecFileName, MissingBaseSpecException}
+  outputTransformers:    Seq[OutputTransformer] = Nil)(implicit cl: ClassLoader) {
+  import SwaggerSpecGenerator.{ customMappingsFileName, baseSpecFileName, MissingBaseSpecException }
   // routes with their prefix
   type Routes = (String, Seq[Route])
 
@@ -46,8 +45,7 @@ final case class SwaggerSpecGenerator(
 
   private[playSwagger] def generateFromRoutesFile(
     routesFile: String   = defaultRoutesFile,
-    base:       JsObject = Json.obj()
-  ): Try[JsObject] = {
+    base:       JsObject = Json.obj()): Try[JsObject] = {
 
     def tagFromFile(file: String) = file.replace(routesExt, "")
 
@@ -121,8 +119,7 @@ final case class SwaggerSpecGenerator(
 
   private[playSwagger] def generateWithBase(
     paths:    ListMap[String, JsObject],
-    baseJson: JsObject                  = Json.obj()
-  ): JsObject = {
+    baseJson: JsObject                  = Json.obj()): JsObject = {
     val pathsJson = paths.values.reduce(_ ++ _)
     val allRefs = (pathsJson ++ baseJson) \\ "$ref"
 
@@ -142,18 +139,15 @@ final case class SwaggerSpecGenerator(
     //TODO: remove hardcoded path
     val generatedTagsJson = JsArray(
       paths.keys
-      //.filterNot(_ == RoutesFileReader.rootRoute)
-      .map(tag ⇒ Json.obj("name" → tag)).toSeq
-    )
+        //.filterNot(_ == RoutesFileReader.rootRoute)
+        .map(tag ⇒ Json.obj("name" → tag)).toSeq)
 
     val tagsJson = mergeByName(generatedTagsJson, (baseJson \ "tags").asOpt[JsArray].getOrElse(JsArray()))
 
     Json.obj(
       "paths" → pathsJson,
-      "definitions" → definitionsJson
-    ).deepMerge(baseJson) + (
-        "tags" → tagsJson
-      )
+      "definitions" → definitionsJson).deepMerge(baseJson) + (
+        "tags" → tagsJson)
   }
 
   private val referencePrefix = "#/definitions/"
@@ -171,8 +165,7 @@ final case class SwaggerSpecGenerator(
     (__ \ 'example).writeNullable[JsValue] ~
     (__ \ "schema").writeNullable[String](refWrite) ~
     (__ \ "items").writeNullable[SwaggerParameter](propWrites) ~
-    (__ \ "enum").writeNullable[Seq[String]]
-  )(unlift(GenSwaggerParameter.unapply))
+    (__ \ "enum").writeNullable[Seq[String]])(unlift(GenSwaggerParameter.unapply))
 
   private def customParamWrites(csp: CustomSwaggerParameter): List[JsObject] = {
     csp.specAsParameter match {
@@ -180,10 +173,8 @@ final case class SwaggerSpecGenerator(
         val w = (
           (__ \ 'name).write[String] ~
           (__ \ 'required).write[Boolean] ~
-          (__ \ 'default).writeNullable[JsValue]
-        )(
-            (c: CustomSwaggerParameter) ⇒ (c.name, c.required, c.default)
-          )
+          (__ \ 'default).writeNullable[JsValue])(
+            (c: CustomSwaggerParameter) ⇒ (c.name, c.required, c.default))
 
         (w.writes(csp) ++ head) :: tail
       case Nil ⇒ Nil
@@ -207,8 +198,7 @@ final case class SwaggerSpecGenerator(
     (__ \ 'example).writeNullable[JsValue] ~
     (__ \ "$ref").writeNullable[String] ~
     (__ \ "items").lazyWriteNullable[SwaggerParameter](propWrites) ~
-    (__ \ "enum").writeNullable[Seq[String]]
-  )(p ⇒ (p.`type`, p.format, p.default, p.example, p.referenceType.map(referencePrefix + _), p.items, p.enum))
+    (__ \ "enum").writeNullable[Seq[String]])(p ⇒ (p.`type`, p.format, p.default, p.example, p.referenceType.map(referencePrefix + _), p.items, p.enum))
 
   implicit class PathAdditions(path: JsPath) {
     def writeNullableIterable[A <: Iterable[_]](implicit writes: Writes[A]): OWrites[A] =
@@ -225,8 +215,7 @@ final case class SwaggerSpecGenerator(
   private implicit val defFormat: Writes[Definition] = (
     (__ \ 'description).writeNullable[String] ~
     (__ \ 'properties).write[Seq[SwaggerParameter]] ~
-    (__ \ 'required).writeNullable[Seq[String]]
-  )((d: Definition) ⇒ (d.description, d.properties, requiredProperties(d.properties)))
+    (__ \ 'required).writeNullable[Seq[String]])((d: Definition) ⇒ (d.description, d.properties, requiredProperties(d.properties)))
 
   private def requiredProperties(properties: Seq[SwaggerParameter]): Option[Seq[String]] = {
     val required = properties.filter(_.required).map(_.name)
@@ -319,8 +308,7 @@ final case class SwaggerSpecGenerator(
     else
       "/" + List(
         prefix.stripPrefix("/").stripSuffix("/"),
-        inRoutePath.stripPrefix("/")
-      ).filterNot(_.isEmpty).
+        inRoutePath.stripPrefix("/")).filterNot(_.isEmpty).
         mkString("/")
 
   // Multiple routes may have the same path, merge the objects instead of overwriting
@@ -392,8 +380,7 @@ final case class SwaggerSpecGenerator(
     val parameterJson = if (mergedParams.value.nonEmpty) Json.obj("parameters" → mergedParams) else Json.obj()
 
     val operationId = Json.obj(
-      "operationId" → route.call.method
-    )
+      "operationId" → route.call.method)
 
     val rawPathJson = operationId ++ tag.fold(Json.obj()) { t ⇒
       Json.obj("tags" → List(t))

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
@@ -1,8 +1,8 @@
 package com.iheart.playSwagger
 
-import java.nio.file.{Files, Paths, StandardOpenOption}
+import java.nio.file.{ Files, Paths, StandardOpenOption }
 
-import scala.util.{Success, Failure, Try}
+import scala.util.{ Success, Failure, Try }
 
 object SwaggerSpecRunner extends App {
   implicit def cl = getClass.getClassLoader

--- a/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
@@ -131,9 +131,7 @@ class DefinitionGeneratorSpec extends Specification {
         val mappings = List(
           CustomTypeMapping(
             `type` = "org.joda.time.DateTime",
-            specAsParameter = customJson
-          )
-        )
+            specAsParameter = customJson))
         val result = DefinitionGenerator("com.iheart", mappings).definition("com.iheart.playSwagger.WithDate")
         val prop = result.properties.head.asInstanceOf[CustomSwaggerParameter]
         prop.specAsParameter === customJson
@@ -144,8 +142,7 @@ class DefinitionGeneratorSpec extends Specification {
       val customJson = List(Json.obj("type" → "string"))
       val customMapping = CustomTypeMapping(
         `type` = "com.iheart.playSwagger.WrappedString",
-        specAsParameter = customJson
-      )
+        specAsParameter = customJson)
       val generator = DefinitionGenerator("com.iheart", List(customMapping))
       val definition = generator.definition[FooWithWrappedStringProperties]
 

--- a/core/src/test/scala/com/iheart/playSwagger/OutputTransformerSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/OutputTransformerSpec.scala
@@ -4,7 +4,7 @@ import com.iheart.playSwagger.OutputTransformer.SimpleOutputTransformer
 import org.specs2.mutable.Specification
 import play.api.libs.json._
 
-import scala.util.{Failure, Success}
+import scala.util.{ Failure, Success }
 
 class OutputTransformerSpec extends Specification {
   "OutputTransformer.traverseTransformer" >> {
@@ -12,8 +12,7 @@ class OutputTransformerSpec extends Specification {
     "traverse and transform object and update simple paths" >> {
       val result = OutputTransformer.traverseTransformer(Json.obj(
         "a" → 1,
-        "b" → "c"
-      )) { _ ⇒ Success(JsNumber(10)) }
+        "b" → "c")) { _ ⇒ Success(JsNumber(10)) }
       result === Success(Json.obj("a" → 10, "b" → 10))
     }
 
@@ -21,9 +20,7 @@ class OutputTransformerSpec extends Specification {
       val result = OutputTransformer.traverseTransformer(Json.obj(
         "a" → 1,
         "b" → Json.obj(
-          "c" → 1
-        )
-      )) { _ ⇒ Success(JsNumber(10)) }
+          "c" → 1))) { _ ⇒ Success(JsNumber(10)) }
       result === Success(Json.obj("a" → 10, "b" → Json.obj("c" → 10)))
     }
 
@@ -33,14 +30,11 @@ class OutputTransformerSpec extends Specification {
         "b" → Json.arr(
           Json.obj("c" → 1),
           Json.obj("d" → 1),
-          Json.obj("e" → 1)
-        )
-      )) { _ ⇒ Success(JsNumber(10)) }
+          Json.obj("e" → 1)))) { _ ⇒ Success(JsNumber(10)) }
       result === Success(Json.obj("a" → 10, "b" → Json.arr(
         Json.obj("c" → 10),
         Json.obj("d" → 10),
-        Json.obj("e" → 10)
-      )))
+        Json.obj("e" → 10))))
     }
 
     "return a failure when there's a problem transforming data" >> {
@@ -48,9 +42,7 @@ class OutputTransformerSpec extends Specification {
       val result = OutputTransformer.traverseTransformer(Json.obj(
         "a" → 1,
         "b" → Json.obj(
-          "c" → 1
-        )
-      )) { _ ⇒ Failure(err) }
+          "c" → 1))) { _ ⇒ Failure(err) }
       result === Failure(err)
     }
   }
@@ -68,11 +60,9 @@ class OutputTransformerSpec extends Specification {
       val g = a >=> b
       g(Json.obj(
         "A" → "Z",
-        "B" → "Y"
-      )) must beSuccessfulTry.withValue(Json.obj(
+        "B" → "Y")) must beSuccessfulTry.withValue(Json.obj(
         "A" → "Zab",
-        "B" → "Yab"
-      ))
+        "B" → "Yab"))
     }
 
     "fail if one composed function fails" >> {
@@ -88,8 +78,7 @@ class OutputTransformerSpec extends Specification {
       val g = a >=> b
       g(Json.obj(
         "A" → "Z",
-        "B" → "Y"
-      )) must beFailedTry[JsObject].withThrowable[IllegalStateException]("not strings")
+        "B" → "Y")) must beFailedTry[JsObject].withThrowable[IllegalStateException]("not strings")
     }
   }
 }
@@ -102,9 +91,7 @@ class EnvironmentVariablesSpec extends Specification {
       instance(Json.obj(
         "a" → "${A}",
         "b" → Json.obj(
-          "c" → "${C}"
-        )
-      )) === Success(Json.obj("a" → "B", "b" → Json.obj("c" → "D")))
+          "c" → "${C}"))) === Success(Json.obj("a" → "B", "b" → Json.obj("c" → "D")))
     }
 
     "return failure when using non present environment variables" >> {
@@ -113,9 +100,7 @@ class EnvironmentVariablesSpec extends Specification {
       instance(Json.obj(
         "a" → "${A}",
         "b" → Json.obj(
-          "c" → "${NON_EXISTING}"
-        )
-      )) must beFailedTry[JsObject].withThrowable[IllegalStateException]("Unable to find variable NON_EXISTING")
+          "c" → "${NON_EXISTING}"))) must beFailedTry[JsObject].withThrowable[IllegalStateException]("Unable to find variable NON_EXISTING")
     }
   }
 }
@@ -128,8 +113,7 @@ class EnvironmentVariablesIntegrationSpec extends Specification {
       val envs = Map("LAST_TRACK_DESCRIPTION" → "Last track", "PLAYED_TRACKS_DESCRIPTION" → "Add tracks")
       val json = SwaggerSpecGenerator(
         PrefixDomainModelQualifier("com.iheart"),
-        outputTransformers = MapVariablesTransformer(envs) :: Nil
-      ).generate("env.routes").get
+        outputTransformers = MapVariablesTransformer(envs) :: Nil).generate("env.routes").get
       val pathJson = json \ "paths"
       val stationJson = (pathJson \ "/api/station/{sid}/playedTracks/last" \ "get").as[JsObject]
       val addTrackJson = (pathJson \ "/api/station/playedTracks" \ "post").as[JsObject]
@@ -143,8 +127,7 @@ class EnvironmentVariablesIntegrationSpec extends Specification {
     val envs = Map("LAST_TRACK_DESCRIPTION" → "Last track")
     val json = SwaggerSpecGenerator(
       PrefixDomainModelQualifier("com.iheart"),
-      outputTransformers = MapVariablesTransformer(envs) :: Nil
-    ).generate("env.routes")
+      outputTransformers = MapVariablesTransformer(envs) :: Nil).generate("env.routes")
     json must beFailedTry[JsObject].withThrowable[IllegalStateException]("Unable to find variable PLAYED_TRACKS_DESCRIPTION")
   }
 }

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -1,7 +1,7 @@
 package com.iheart.playSwagger
 
 import org.specs2.mutable.Specification
-import play.api.libs.json.{Json, JsString}
+import play.api.libs.json.{ Json, JsString }
 import com.iheart.playSwagger.Domain._
 import play.routes.compiler.Parameter
 
@@ -14,8 +14,7 @@ class SwaggerParameterMapperSpec extends Specification {
       mapParam(Parameter("fieldWithDateTime", "org.joda.time.DateTime", None, None)) === GenSwaggerParameter(
         name = "fieldWithDateTime",
         `type` = Option("integer"),
-        format = Option("epoch")
-      )
+        format = Option("epoch"))
     }
 
     "override mapping to map DateTime to string with format date-time" >> {
@@ -23,8 +22,7 @@ class SwaggerParameterMapperSpec extends Specification {
         val specAsParameter = List(Json.obj("type" → "string", "format" → "date-time"))
         val mappings: CustomMappings = List(CustomTypeMapping(
           "org.joda.time.DateTime",
-          specAsParameter = specAsParameter
-        ))
+          specAsParameter = specAsParameter))
 
         val parameter = mapParam(Parameter("fieldWithDateTimeOverRide", "org.joda.time.DateTime", None, None), customMappings = mappings)
         parameter.name mustEqual "fieldWithDateTimeOverRide"
@@ -36,8 +34,7 @@ class SwaggerParameterMapperSpec extends Specification {
         val specAsProperty = Json.obj("type" → "string", "format" → "date-time")
         val mappings: CustomMappings = List(CustomTypeMapping(
           "org.joda.time.DateTime",
-          specAsProperty = Some(specAsProperty)
-        ))
+          specAsProperty = Some(specAsProperty)))
         val parameter = mapParam(Parameter("seqWithDateTimeOverRide", "Option[Seq[org.joda.time.DateTime]]", None, None), customMappings = mappings).asInstanceOf[GenSwaggerParameter]
 
         parameter.name mustEqual "seqWithDateTimeOverRide"
@@ -55,8 +52,7 @@ class SwaggerParameterMapperSpec extends Specification {
       val specAsParameter = List(Json.obj("type" → "string", "format" → "date-time"))
       val mappings: CustomMappings = List(CustomTypeMapping(
         "java.util.Date",
-        specAsParameter = specAsParameter
-      ))
+        specAsParameter = specAsParameter))
       val parameter = mapParam(Parameter("fieldWithDate", "java.util.Date", None, None), customMappings = mappings)
       parameter.name mustEqual "fieldWithDate"
       parameter must beAnInstanceOf[CustomSwaggerParameter]
@@ -67,24 +63,21 @@ class SwaggerParameterMapperSpec extends Specification {
       mapParam(Parameter("fieldWithAny", "Any", None, None)) === GenSwaggerParameter(
         name = "fieldWithAny",
         `type` = Option("any"),
-        example = Option(JsString("any JSON value"))
-      )
+        example = Option(JsString("any JSON value")))
     }
 
     "map java enum to enum constants" >> {
       mapParam(Parameter("javaEnum", "com.iheart.playSwagger.SampleJavaEnum", None, None)) === GenSwaggerParameter(
         name = "javaEnum",
         `type` = Option("string"),
-        enum = Option(Seq("DISABLED", "ACTIVE"))
-      )
+        enum = Option(Seq("DISABLED", "ACTIVE")))
     }
 
     "map scala enum to enum constants" >> {
       mapParam(Parameter("scalaEnum", "com.iheart.playSwagger.SampleScalaEnum.Value", None, None)) === GenSwaggerParameter(
         name = "scalaEnum",
         `type` = Option("string"),
-        enum = Option(Seq("One", "Two"))
-      )
+        enum = Option(Seq("One", "Two")))
     }
 
     //TODO: for sequences, should the nested required be ignored?
@@ -96,9 +89,7 @@ class SwaggerParameterMapperSpec extends Specification {
         items = Some(GenSwaggerParameter(
           name = "aField",
           required = true,
-          `type` = Some("string")
-        ))
-      )
+          `type` = Some("string"))))
     }
 
     "map String to string without override interference" >> {
@@ -106,11 +97,9 @@ class SwaggerParameterMapperSpec extends Specification {
       val specAsParameter = List(Json.obj("type" → "string", "format" → "date-time"))
       val mappings: CustomMappings = List(CustomTypeMapping(
         "java.time.LocalDate",
-        specAsParameter = specAsParameter
-      ), CustomTypeMapping(
+        specAsParameter = specAsParameter), CustomTypeMapping(
         "java.time.Duration",
-        specAsParameter = specAsParameter
-      ))
+        specAsParameter = specAsParameter))
       val parameter = mapParam(Parameter("strField", "String", None, None), customMappings = mappings)
       parameter.name mustEqual "strField"
       parameter must beAnInstanceOf[GenSwaggerParameter]
@@ -123,24 +112,21 @@ class SwaggerParameterMapperSpec extends Specification {
         name = "strField",
         `type` = Option("string"),
         required = false,
-        default = Option(JsString("defaultValue"))
-      )
+        default = Option(JsString("defaultValue")))
     }
     "map default value to content without quotes when provided with string with simple quotes" >> {
       mapParam(Parameter("strField", "String", None, Some("\"defaultValue\""))) === GenSwaggerParameter(
         name = "strField",
         `type` = Option("string"),
         required = false,
-        default = Option(JsString("defaultValue"))
-      )
+        default = Option(JsString("defaultValue")))
     }
     "map default value to content without quotes when provided with string with triple quotes" >> {
       mapParam(Parameter("strField", "String", None, Some("\"\"\"defaultValue\"\"\""))) === GenSwaggerParameter(
         name = "strField",
         `type` = Option("string"),
         required = false,
-        default = Option(JsString("defaultValue"))
-      )
+        default = Option(JsString("defaultValue")))
     }
   }
 }

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -1,6 +1,6 @@
 package com.iheart.playSwagger
 
-import com.iheart.playSwagger.Domain.{CustomTypeMapping, CustomMappings}
+import com.iheart.playSwagger.Domain.{ CustomTypeMapping, CustomMappings }
 import org.specs2.mutable.Specification
 import play.api.libs.json._
 
@@ -345,9 +345,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
         "type" → "object",
         "properties" → Json.obj(
           "id" → Json.obj("type" → "string"),
-          "value" → Json.obj("type" → "string")
-        )
-      )
+          "value" → Json.obj("type" → "string")))
     }
 
     "definition properties does not contain 'required' boolean field" >> {
@@ -452,7 +450,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
       third must beSome[Int]
       fourth must beSome[Int]
 
-      // must be in exact order with nothing inbetween 
+      // must be in exact order with nothing inbetween
       second.get - first.get === 1
       third.get - second.get === 1
       fourth.get - third.get === 1

--- a/example/app/Filters.scala
+++ b/example/app/Filters.scala
@@ -20,7 +20,7 @@ import filters.ExampleFilter
  */
 @Singleton
 class Filters @Inject() (
-  env: Environment,
+  env:           Environment,
   exampleFilter: ExampleFilter) extends HttpFilters {
 
   override val filters = {

--- a/example/app/Module.scala
+++ b/example/app/Module.scala
@@ -1,13 +1,13 @@
 import com.google.inject.AbstractModule
 import java.time.Clock
 
-import services.{ApplicationTimer, AtomicCounter, Counter}
+import services.{ ApplicationTimer, AtomicCounter, Counter }
 
 /**
  * This class is a Guice module that tells Guice how to bind several
  * different types. This Guice module is created when the Play
  * application starts.
-
+ *
  * Play will automatically use any class called `Module` that is in
  * the root package. You can create modules in other locations by
  * adding `play.modules.enabled` settings to the `application.conf`

--- a/example/app/controllers/AsyncController.scala
+++ b/example/app/controllers/AsyncController.scala
@@ -6,7 +6,7 @@ import models.Message
 import play.api._
 import play.api.libs.json.Json
 import play.api.mvc._
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.concurrent.duration._
 
 /**
@@ -31,7 +31,7 @@ class AsyncController @Inject() (actorSystem: ActorSystem)(implicit exec: Execut
    * a path of `/message`.
    */
   def message = Action.async {
-    getFutureMessage(1.second).map { msg => Ok(Json.toJson(msg)) }
+    getFutureMessage(1.second).map { msg ⇒ Ok(Json.toJson(msg)) }
   }
 
   private def getFutureMessage(delayTime: FiniteDuration): Future[Message] = {

--- a/example/app/filters/ExampleFilter.scala
+++ b/example/app/filters/ExampleFilter.scala
@@ -3,7 +3,7 @@ package filters
 import akka.stream.Materializer
 import javax.inject._
 import play.api.mvc._
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * This is a simple filter that adds a header to all requests. It's
@@ -16,16 +16,16 @@ import scala.concurrent.{ExecutionContext, Future}
  * It is used below by the `map` method.
  */
 @Singleton
-class ExampleFilter @Inject()(
-    implicit override val mat: Materializer,
-    exec: ExecutionContext) extends Filter {
+class ExampleFilter @Inject() (
+  implicit
+  override val mat: Materializer,
+  exec:             ExecutionContext) extends Filter {
 
-  override def apply(nextFilter: RequestHeader => Future[Result])
-           (requestHeader: RequestHeader): Future[Result] = {
+  override def apply(nextFilter: RequestHeader ⇒ Future[Result])(requestHeader: RequestHeader): Future[Result] = {
     // Run the next filter in the chain. This will call other filters
     // and eventually call the action. Take the result and modify it
     // by adding a new header.
-    nextFilter(requestHeader).map { result =>
+    nextFilter(requestHeader).map { result ⇒
       result.withHeaders("X-ExampleFilter" -> "foo")
     }
   }

--- a/example/app/services/ApplicationTimer.scala
+++ b/example/app/services/ApplicationTimer.scala
@@ -1,6 +1,6 @@
 package services
 
-import java.time.{Clock, Instant}
+import java.time.{ Clock, Instant }
 import javax.inject._
 import play.api.Logger
 import play.api.inject.ApplicationLifecycle
@@ -30,7 +30,7 @@ class ApplicationTimer @Inject() (clock: Clock, appLifecycle: ApplicationLifecyc
   // When the application starts, register a stop hook with the
   // ApplicationLifecycle object. The code inside the stop hook will
   // be run when the application stops.
-  appLifecycle.addStopHook { () =>
+  appLifecycle.addStopHook { () ⇒
     val stop: Instant = clock.instant
     val runningTime: Long = stop.getEpochSecond - start.getEpochSecond
     Logger.info(s"ApplicationTimer demo: Stopping application at ${clock.instant} after ${runningTime}s.")

--- a/example/app/services/Counter.scala
+++ b/example/app/services/Counter.scala
@@ -23,7 +23,7 @@ trait Counter {
  * injected.
  */
 @Singleton
-class AtomicCounter extends Counter {  
+class AtomicCounter extends Counter {
   private val atomicCounter = new AtomicInteger()
   override def nextCount(): Int = atomicCounter.getAndIncrement()
 }

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, SwaggerPlugin) //enable plugin
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.11"
 
 libraryDependencies ++= Seq(
   jdbc,

--- a/example/project/build.properties
+++ b/example/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Wed Aug 24 09:12:28 EDT 2016
 template.uuid=b0d11fa6-d1b3-4963-94aa-319a15612bf3
-sbt.version=0.13.11
+sbt.version=0.13.16

--- a/example/project/plugins.sbt
+++ b/example/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.6")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.16")
 
 // web plugins
 
@@ -18,6 +18,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.1.0")
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.2")
 
 // play swagger plugin
-addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.5.3")
+addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.6.2")
 
 

--- a/example/test/ApplicationSpec.scala
+++ b/example/test/ApplicationSpec.scala
@@ -11,7 +11,7 @@ class ApplicationSpec extends PlaySpec with OneAppPerTest {
 
   "Routes" should {
 
-    "send 404 on a bad request" in  {
+    "send 404 on a bad request" in {
       route(app, FakeRequest(GET, "/boum")).map(status(_)) mustBe Some(NOT_FOUND)
     }
 
@@ -24,7 +24,7 @@ class ApplicationSpec extends PlaySpec with OneAppPerTest {
 
       status(home) mustBe OK
       contentType(home) mustBe Some("text/html")
-      contentAsString(home) must include ("Your new application is ready.")
+      contentAsString(home) must include("Your new application is ready.")
     }
 
   }

--- a/example/test/IntegrationSpec.scala
+++ b/example/test/IntegrationSpec.scala
@@ -14,7 +14,7 @@ class IntegrationSpec extends PlaySpec with OneServerPerTest with OneBrowserPerT
 
       go to ("http://localhost:" + port)
 
-      pageSource must include ("Your new application is ready.")
+      pageSource must include("Your new application is ready.")
     }
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,29 +2,24 @@ import sbt._
 
 object Dependencies {
   object Versions {
-    val play = "2.5.14"
-    val specs2 = "3.8.9"
+    val play = "2.5.16"
+    val specs2 = "3.9.5"
   }
 
   val playTest = Seq(
-    "com.typesafe.play" %% "play-test" % Versions.play % Test
-  )
+    "com.typesafe.play" %% "play-test" % Versions.play % Test)
 
   val playRoutesCompiler = Seq(
-    "com.typesafe.play" %% "routes-compiler" % Versions.play
-  )
+    "com.typesafe.play" %% "routes-compiler" % Versions.play)
 
   val playJson = Seq(
-    "com.typesafe.play" %% "play-json" % Versions.play % "provided"
-  )
+    "com.typesafe.play" %% "play-json" % Versions.play % "provided")
 
   val yaml = Seq(
-    "org.yaml" % "snakeyaml" % "1.16"
-  )
+    "org.yaml" % "snakeyaml" % "1.18")
 
   val test = Seq(
     "org.specs2" %% "specs2-core" % Versions.specs2 % "test",
-    "org.specs2" %% "specs2-mock" % Versions.specs2 % "test"
-  )
+    "org.specs2" %% "specs2-mock" % Versions.specs2 % "test")
 
 }

--- a/project/Format.scala
+++ b/project/Format.scala
@@ -4,9 +4,8 @@ import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
 object Format {
   lazy val settings = SbtScalariform.scalariformSettings ++ Seq(
-    ScalariformKeys.preferences in Compile  := formattingPreferences,
-    ScalariformKeys.preferences in Test     := formattingPreferences
-  )
+    ScalariformKeys.preferences in Compile := formattingPreferences,
+    ScalariformKeys.preferences in Test := formattingPreferences)
 
   def formattingPreferences = {
     import scalariform.formatter.preferences._

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -1,7 +1,6 @@
 import sbt._, Keys._
 import bintray.BintrayKeys._
 
-
 object Publish {
 
   val coreSettings = Seq(
@@ -10,15 +9,14 @@ object Publish {
     publishMavenStyle := true,
     licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
     homepage := Some(url("http://iheartradio.github.io/play-swagger")),
-    scmInfo := Some(ScmInfo(url("https://github.com/iheartradio/play-swagger"),
+    scmInfo := Some(ScmInfo(
+      url("https://github.com/iheartradio/play-swagger"),
       "git@github.com:iheartradio/play-swagger.git")),
-    pomIncludeRepository := { _ => false },
-    publishArtifact in Test := false
-  )
+    pomIncludeRepository := { _ ⇒ false },
+    publishArtifact in Test := false)
 
   val sbtPluginSettings = Seq(
     licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
     publishMavenStyle := false,
-    bintrayOrganization := Some("iheartradio")
-  )
+    bintrayOrganization := Some("iheartradio"))
 }

--- a/project/ScriptedTesting.scala
+++ b/project/ScriptedTesting.scala
@@ -9,8 +9,6 @@ object ScriptedTesting {
     scriptedBufferLog := false,
     scriptedLaunchOpts := scriptedLaunchOpts.value ++ Seq(
       "-Xmx1024M",
-      "-Dplugin.version=" + version.value
-    ),
-    test in Test := (test in Test).dependsOn(scripted.toTask("")).value
-  )
+      "-Dplugin.version=" + version.value),
+    test in Test := (test in Test).dependsOn(scripted.toTask("")).value)
 }

--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -4,10 +4,6 @@ import sbt.Keys._
 
 object Testing {
 
-
   lazy val settings = Seq(
-    scalacOptions in Test ++= Seq("-Yrangepos")
-  )
-
-
+    scalacOptions in Test ++= Seq("-Yrangepos"))
 }

--- a/project/Versioning.scala
+++ b/project/Versioning.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object Versioning {
 
-  def writeVersionFile(path: String) = Def.task{
+  def writeVersionFile(path: String) = Def.task {
     val file = (resourceManaged in Compile).value / path
     IO.write(file, version.value.getBytes)
     Seq(file)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,12 @@
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.5")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
@@ -2,7 +2,7 @@ package com.iheart.sbtPlaySwagger
 
 import java.io.File
 
-import sbt.{SettingKey, TaskKey}
+import sbt.{ SettingKey, TaskKey }
 
 trait SwaggerKeys {
   val swagger = TaskKey[File]("swagger", "generates the swagger API documentation")

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
@@ -38,7 +38,7 @@ object SwaggerPlugin extends AutoPlugin {
       val args: Seq[String] = file.absolutePath :: swaggerRoutesFile.value ::
         swaggerDomainNameSpaces.value.mkString(",") :: swaggerOutputTransformers.value.mkString(",") :: Nil
       val swaggerClasspath = data((fullClasspath in Runtime).value) ++ update.value.select(configurationFilter(swaggerConfig.name))
-      runner.value.run("com.iheart.playSwagger.SwaggerSpecRunner", swaggerClasspath, args, streams.value.log).foreach(sys.error)
+      runner.value.run("com.iheart.playSwagger.SwaggerSpecRunner", swaggerClasspath, args, streams.value.log)
       file
     }.value,
     unmanagedResourceDirectories in Assets += swaggerTarget.value,

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
@@ -4,7 +4,7 @@ import com.typesafe.sbt.packager.archetypes.JavaAppPackaging
 import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport._
 import sbt.Attributed._
 import sbt.Keys._
-import sbt.{AutoPlugin, _}
+import sbt.{ AutoPlugin, _ }
 import com.typesafe.sbt.web.Import._
 
 object SwaggerPlugin extends AutoPlugin {
@@ -32,20 +32,19 @@ object SwaggerPlugin extends AutoPlugin {
     swaggerRoutesFile := "routes",
     swaggerOutputTransformers := Seq(),
     swagger := Def.task[File] {
-      (swaggerTarget.value).mkdirs()
+      swaggerTarget.value.mkdirs()
       val file = swaggerTarget.value / swaggerFileName.value
       IO.delete(file)
       val args: Seq[String] = file.absolutePath :: swaggerRoutesFile.value ::
         swaggerDomainNameSpaces.value.mkString(",") :: swaggerOutputTransformers.value.mkString(",") :: Nil
       val swaggerClasspath = data((fullClasspath in Runtime).value) ++ update.value.select(configurationFilter(swaggerConfig.name))
-      toError(runner.value.run("com.iheart.playSwagger.SwaggerSpecRunner", swaggerClasspath, args, streams.value.log))
+      runner.value.run("com.iheart.playSwagger.SwaggerSpecRunner", swaggerClasspath, args, streams.value.log).foreach(sys.error)
       file
     }.value,
     unmanagedResourceDirectories in Assets += swaggerTarget.value,
     mappings in (Compile, packageBin) += (swaggerTarget.value / swaggerFileName.value) → s"public/${swaggerFileName.value}", //include it in the unmanagedResourceDirectories in Assets doesn't automatically include it package
     packageBin in Universal := (packageBin in Universal).dependsOn(swagger).value,
     run := (run in Compile).dependsOn(swagger).evaluated,
-    stage := stage.dependsOn(swagger).value
-  )
+    stage := stage.dependsOn(swagger).value)
 }
 

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/app/namespace1/Artist.scala
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/app/namespace1/Artist.scala
@@ -1,5 +1,6 @@
 package namespace1
 
-case class Artist(name: String,
-                  age: Int,
-                  birthdate: java.time.LocalDate)
+case class Artist(
+  name:      String,
+  age:       Int,
+  birthdate: java.time.LocalDate)

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/app/namespace2/Track.scala
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/app/namespace2/Track.scala
@@ -2,9 +2,10 @@ package namespace2
 
 import namespace1.Artist
 
-case class Track(name: String,
-                 genre: Option[String],
-                 artist: Artist,
-                 related: Seq[Artist],
-                 numbers: Seq[Int],
-                 length: java.time.Duration)
+case class Track(
+  name:    String,
+  genre:   Option[String],
+  artist:  Artist,
+  related: Seq[Artist],
+  numbers: Seq[Int],
+  length:  java.time.Duration)

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
@@ -8,7 +8,7 @@ enablePlugins(PlayScala, SwaggerPlugin)
 
 name := "app"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.11"
 
 swaggerDomainNameSpaces := Seq("namespace1", "namespace2")
 

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
@@ -1,7 +1,6 @@
 import org.json4s._
-
 import org.json4s.native.JsonMethods._
-import org.json4s.native.JsonMethods
+
 logLevel in update := sbt.Level.Warn
 
 enablePlugins(PlayScala, SwaggerPlugin)

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/project/build.properties
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/project/plugins.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/project/plugins.sbt
@@ -11,4 +11,4 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.16")
   else addSbtPlugin("com.iheart" % "sbt-play-swagger" % pluginVersion)
 }
 
-libraryDependencies += "org.json4s" %% "json4s-native" % "3.5.3"
+libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.10"

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/project/plugins.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/project/plugins.sbt
@@ -1,7 +1,7 @@
 logLevel in update := sbt.Level.Warn
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.6")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.14")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.2.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.16")
 
 {
   val pluginVersion = System.getProperty("plugin.version")
@@ -11,5 +11,4 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.14")
   else addSbtPlugin("com.iheart" % "sbt-play-swagger" % pluginVersion)
 }
 
-
-libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.10"
+libraryDependencies += "org.json4s" %% "json4s-native" % "3.5.3"


### PR DESCRIPTION
refers to https://github.com/iheartradio/play-swagger/issues/177

* bumped scala version to 2.11.11
* bumped sbt plugins to their latest versions
* after upgrading sbt-scalariform the defaults have changed and this resulted in code reformatting
* added cross building for sbt plugins as described in http://www.scala-sbt.org/1.x/docs/Cross-Build-Plugins.html

I'm not sure if this is really what's needed, created PR to get initial feedback (I'll clean up the PR later)

The more straighforward upgrade to sbt 1.0 is blocked by this issue: https://github.com/scoverage/sbt-coveralls/issues/95 the sbt-coveralls plugin used in this project doesn't support sbt 1.0 just yet (it's the only one that's not yet migrated)
Also the Scala 2.12 upgrade is blocked by json4s-native, I haven't checked exactly how to go about it, but upgrading to something newer (which has scala 2.12 releases) will create compilation failures - this is the related issue: https://github.com/json4s/json4s/issues/212