### PR TITLE
Replaced json4s with spray-json for better compatibility between Scala releases

### DIFF
--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
@@ -1,7 +1,6 @@
-import org.json4s._
+import spray.json._
+import DefaultJsonProtocol._
 
-import org.json4s.native.JsonMethods._
-import org.json4s.native.JsonMethods
 logLevel in update := sbt.Level.Warn
 
 enablePlugins(PlayScala, SwaggerPlugin)
@@ -20,7 +19,8 @@ val pathVal = System.getenv("PATH")
 
 TaskKey[Unit]("check") := {
 
-  def uniform(jsString: String): String = pretty(render(parse(jsString)))
+  def uniform(jsString: String): String = jsString.parseJson.prettyPrint
+
   val expected = uniform(
     s"""
       |{

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/project/plugins.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/project/plugins.sbt
@@ -11,5 +11,4 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.14")
   else addSbtPlugin("com.iheart" % "sbt-play-swagger" % pluginVersion)
 }
 
-
-libraryDependencies += "org.json4s" %% "json4s-native" % "3.2.10"
+libraryDependencies += "io.spray" %% "spray-json" % "1.3.3"


### PR DESCRIPTION
There are binary compatibility issues in the json4s releases that make it difficult to compile project with different releases of scala, on top of that, spray-json v 1.3.3 is released for Scala 2.10, 2.11, 2.12, there's no single version of json4s that's supported by those 3 versions of Scala