### PR TITLE
fix a type error for swaggerTarget in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ SwaggerSpecGenerator(domainPackage).generate("myRoutes.routes")
 #### How do I change the location of the swagger documentation in the packaged app?
 In build.sbt, add
 ```scala
-swaggerTarget := "path/to/swagger/location"
+swaggerTarget := new File("path/to/swagger/location")
 ```
 
 #### How do I change the filename of the swagger documentation in the packaged app?


### PR DESCRIPTION
## Problem

`swaggerTarget := "path/to/swagger/location"`

This sample code in README file produces the following error.

```text
Error:Error while importing SBT project:
...
.../build.sbt:42: error: type mismatch;
found   : String("path/to/swagger/location")
required: java.io.File
swaggerTarget := "path/to/swagger/location"
^
[error] Type error in expression
Invalid response.</pre>
```

According to the type definition, we have to pass a java.io.File instance.

https://github.com/iheartradio/play-swagger/blob/cfbab7e76f7b9fe44414395688cb04fb1c7fda4c/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala#L10

## Environment

- sbt: 1.0.3
- play-swagger: 0.7.1