### PR TITLE
Ensure that definitions are retained for refs in custom mappings

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -121,7 +121,15 @@ final case class SwaggerSpecGenerator(
     paths:    ListMap[String, JsObject],
     baseJson: JsObject                  = Json.obj()): JsObject = {
     val pathsJson = paths.values.reduce(_ ++ _)
-    val allRefs = (pathsJson ++ baseJson) \\ "$ref"
+
+    val refKey = "$ref"
+    val mainRefs = (pathsJson ++ baseJson) \\ refKey
+    val customMappingRefs = for {
+      customMapping ← customMappings
+      mappingsJson = customMapping.specAsProperty.toSeq ++ customMapping.specAsParameter
+      ref ← mappingsJson.flatMap(_ \\ refKey)
+    } yield ref
+    val allRefs = mainRefs ++ customMappingRefs
 
     val definitions: List[Definition] = {
       val referredClasses: Seq[String] = for {

--- a/core/src/test/resources/swagger-custom-mappings.yml
+++ b/core/src/test/resources/swagger-custom-mappings.yml
@@ -15,3 +15,7 @@
     specAsParameter: []
     specAsProperty:
       $ref: "#/definitions/Keeper"
+  - type: com\.iheart\.playSwagger\.Parent
+    specAsParameter: []
+    specAsProperty:
+      $ref: "#/definitions/com.iheart.playSwagger.Child"

--- a/core/src/test/resources/test.routes
+++ b/core/src/test/resources/test.routes
@@ -66,3 +66,13 @@ POST     /somethingOptional                controllers.Player.somethingOptional(
 #     type: string
 ###
 POST  /iWantAQueryBody                     controllers.Test.queryBodyHandler(body)
+
+###
+#  responses:
+#    default:
+#      description: Something optional
+#      schema:
+#        $ref: '#/definitions/com.iheart.playSwagger.Parent'
+###
+GET  /iWantAChild                     controllers.Test.queryForChild
+

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -21,6 +21,9 @@ case class EnumContainer(javaEnum: SampleJavaEnum, scalaEnum: SampleScalaEnum.Sa
 
 case class AllOptional(a: Option[String], b: Option[String])
 
+trait Parent
+case class Child(name: String) extends Parent
+
 class SwaggerSpecGeneratorSpec extends Specification {
   implicit val cl = getClass.getClassLoader
   val gen = SwaggerSpecGenerator()
@@ -456,6 +459,9 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
       fourth.get - third.get === 1
     }
 
+    "should retain $refs in 'swagger-custom-mappings'" >> {
+      (definitionsJson \ "com.iheart.playSwagger.Child").isDefined === true
+    }
   }
 
 }

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -460,7 +460,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     }
 
     "should retain $refs in 'swagger-custom-mappings'" >> {
-      (definitionsJson \ "com.iheart.playSwagger.Child").isDefined === true
+      (definitionsJson \ "com.iheart.playSwagger.Child").toOption.isDefined === true
     }
   }
 


### PR DESCRIPTION
This is to support mapping sealed case classes once we have support for Swagger v3.  With this, we can specify a custom mapping for the sealed trait that specifies that which child classes can fulfill that trait.  For example (this only works with Swagger v3 due to the use of `oneOf`):
```
  - type: com\.package\.ParentTrait
    specAsParameter:
      - oneOf:
        - $ref: '#/definitions/com.package.Child1'
        - $ref: '#/definitions/com.package.Child2'
``` 