### PR TITLE
Final v3 fixes

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -181,7 +181,7 @@ final case class SwaggerSpecGenerator(
       (__ \ "schema").writeNullable[String](refWrite) ~
       (under \ 'type).writeNullable[String] ~
       (under \ 'format).writeNullable[String] ~
-      (under \ 'required).write[Boolean] ~
+      (__ \ 'required).write[Boolean] ~
       (under \ 'default).writeNullable[JsValue] ~
       (under \ 'example).writeNullable[JsValue] ~
       (under \ "items").writeNullable[SwaggerParameter](propWrites) ~

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -191,7 +191,7 @@ final case class SwaggerSpecGenerator(
   private def customParamWrites(csp: CustomSwaggerParameter): List[JsObject] = {
     csp.specAsParameter match {
       case head :: tail ⇒
-        def prefixForV3(input: JsObject): JsObject = {
+        def withPrefix(input: JsObject): JsObject = {
           if (swaggerV3) Json.obj("schema" -> input) else input
         }
 
@@ -202,7 +202,7 @@ final case class SwaggerSpecGenerator(
           (under \ 'default).writeNullable[JsValue])(
             (c: CustomSwaggerParameter) ⇒ (c.name, c.required, c.default))
 
-        (w.writes(csp) ++ prefixForV3(head)) :: tail
+        (w.writes(csp) ++ withPrefix(head)) :: tail
       case Nil ⇒ Nil
     }
   }

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -191,13 +191,18 @@ final case class SwaggerSpecGenerator(
   private def customParamWrites(csp: CustomSwaggerParameter): List[JsObject] = {
     csp.specAsParameter match {
       case head :: tail ⇒
+        def prefixForV3(input: JsObject): JsObject = {
+          if (swaggerV3) Json.obj("schema" -> input) else input
+        }
+
+        val under = if (swaggerV3) __ \ "schema" else __
         val w = (
           (__ \ 'name).write[String] ~
           (__ \ 'required).write[Boolean] ~
-          (__ \ 'default).writeNullable[JsValue])(
+          (under \ 'default).writeNullable[JsValue])(
             (c: CustomSwaggerParameter) ⇒ (c.name, c.required, c.default))
 
-        (w.writes(csp) ++ head) :: tail
+        (w.writes(csp) ++ prefixForV3(head)) :: tail
       case Nil ⇒ Nil
     }
   }

--- a/core/src/test/resources/testV3.routes
+++ b/core/src/test/resources/testV3.routes
@@ -13,3 +13,11 @@ GET     /:pid/tracks/search               controllers.Player.searchTrack(pid, ke
 #          $ref: '#/components/schemas/com.iheart.playSwagger.Track'
 ###
 POST     /:pid/playedTracks             controllers.Player.addPlayedTracks(pid)
+
+###
+#  responses:
+#    200:
+#      schema:
+#        $ref: '#/definitions/com.iheart.playSwagger.Animal'
+###
+GET     /zoo/zone/:zid/animals/:aid               controllers.Animals.search(zid: com.iheart.playSwagger.ZoneId, aid: com.iheart.playSwagger.AnimalId)

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -479,6 +479,16 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
       (firstParam \ "schema" \ "type").as[String] === "string"
       (firstParam \ "required").as[Boolean] === true
     }
+
+    "custom param data type values are in the correct location" >> {
+      val parameters = (json \ "paths" \ "/zoo/zone/{zid}/animals/{aid}" \ "get" \ "parameters").as[Seq[JsObject]]
+      parameters.size === 1
+
+      val firstParam = parameters.head
+      (firstParam \ "name").as[String] === "zid"
+      (firstParam \ "schema" \ "type").as[String] === "string"
+      (firstParam \ "required").as[Boolean] === true
+    }
   }
 }
 

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -475,9 +475,9 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
 
     "param data type values are in the correct location" >> {
       val contextParams = json \ "paths" \ "/{pid}/context/{bid}" \ "get" \ "parameters"
-      val schema = contextParams \ 0 \ "schema"
-      (schema \ "type").as[String] === "string"
-      (schema \ "required").as[Boolean] === true
+      val firstParam = contextParams \ 0
+      (firstParam \ "schema" \ "type").as[String] === "string"
+      (firstParam \ "required").as[Boolean] === true
     }
   }
 }


### PR DESCRIPTION
This fixes the location of `required` in params.  It also fixes the format of params that use custom type mappings.

After this, I think the swagger v3 support is complete.  For the project I'm using it on.  I'm now able to get a `swagger.json` that has no validation problems.