### PR TITLE
Use external source to provision description to action parameters and definitions

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/Descriptions.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/Descriptions.scala
@@ -1,0 +1,83 @@
+package com.iheart.playSwagger
+
+import java.io.{ File, FileReader }
+import java.util.Properties
+
+import play.routes.compiler.{ HandlerCall, Parameter }
+
+import scala.reflect.runtime.universe
+import scala.collection.JavaConverters._
+
+object Descriptions {
+
+  trait DescriptionProvider {
+    def getTypeDescription(sym: universe.Symbol): Option[String]
+    def getParamDescription(sym: universe.Symbol, param: String): Option[String]
+    def getMethodParamDescription(call: HandlerCall, paramList: Seq[Parameter], param: Parameter): Option[String]
+  }
+
+  class DescriptionProviderImpl(private val map: Map[String, String]) extends DescriptionProvider {
+    def getTypeDescription(sym: universe.Symbol): Option[String] = {
+      val key = sym.fullName
+      map.get(key)
+    }
+
+    override def getParamDescription(sym: universe.Symbol, param: String): Option[String] = {
+      val key = s"${sym.fullName}.$param"
+      map.get(key)
+    }
+
+    override def getMethodParamDescription(call: HandlerCall, paramList: Seq[Parameter], param: Parameter): Option[String] = {
+      val method = Seq(
+        call.packageName,
+        call.controller,
+        call.method).mkString(".")
+      val params = paramList.map(_.typeName).mkString(",")
+      val key = s"$method($params)#${param.name}"
+      map.get(key)
+    }
+  }
+
+  object DescriptionProviderImpl {
+    /**
+     * Initialize description provider with a properties file.
+     *
+     * @param file
+     * @return
+     */
+    def createFromFile(file: File) = {
+      val props = new Properties()
+      props.load(new FileReader(file))
+
+      val map = props.stringPropertyNames().asScala.map { name ⇒
+        name -> props.getProperty(name)
+      }.toMap
+
+      new DescriptionProviderImpl(map)
+    }
+  }
+
+  /**
+   * A dummy implementation to be used when no description file is supplied.
+   */
+  class EmptyDescriptionProviderImpl extends DescriptionProvider {
+    override def getTypeDescription(sym: universe.Symbol): Option[String] = None
+
+    override def getParamDescription(sym: universe.Symbol, param: String): Option[String] = None
+
+    override def getMethodParamDescription(call: HandlerCall, paramList: Seq[Parameter], param: Parameter): Option[String] = None
+  }
+
+  final val Empty = new EmptyDescriptionProviderImpl
+
+  private var _currentProvider: DescriptionProvider = Empty
+
+  def getProvider: DescriptionProvider = _currentProvider
+
+  def useDescriptionFile(file: File) = {
+    if (file != null && file.exists() && file.isFile) {
+      _currentProvider = DescriptionProviderImpl.createFromFile(file)
+    }
+  }
+
+}

--- a/core/src/main/scala/com/iheart/playSwagger/Domain.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/Domain.scala
@@ -16,6 +16,7 @@ object Domain {
     def name: String
     def required: Boolean
     def default: Option[JsValue]
+    def description: Option[String]
 
     def update(required: Boolean, default: Option[JsValue]): SwaggerParameter
   }
@@ -29,7 +30,8 @@ object Domain {
     default:       Option[JsValue]          = None,
     example:       Option[JsValue]          = None,
     items:         Option[SwaggerParameter] = None,
-    enum:          Option[Seq[String]]      = None) extends SwaggerParameter {
+    enum:          Option[Seq[String]]      = None,
+    description:   Option[String]           = None) extends SwaggerParameter {
     def update(_required: Boolean, _default: Option[JsValue]) =
       copy(required = _required, default = _default)
   }
@@ -39,7 +41,8 @@ object Domain {
     specAsParameter: List[JsObject],
     specAsProperty:  Option[JsObject],
     required:        Boolean          = true,
-    default:         Option[JsValue]  = None) extends SwaggerParameter {
+    default:         Option[JsValue]  = None,
+    description:     Option[String]   = None) extends SwaggerParameter {
     def update(_required: Boolean, _default: Option[JsValue]) =
       copy(required = _required, default = _default)
   }

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -14,7 +14,8 @@ object SwaggerParameterMapper {
   def mapParam(
     parameter:      Parameter,
     modelQualifier: DomainModelQualifier = PrefixDomainModelQualifier(),
-    customMappings: CustomMappings       = Nil)(implicit cl: ClassLoader): SwaggerParameter = {
+    customMappings: CustomMappings       = Nil,
+    description:    Option[String]       = None)(implicit cl: ClassLoader): SwaggerParameter = {
 
     def removeKnownPrefixes(name: String) = name.replaceAll("(scala.)|(java.lang.)|(math.)|(org.joda.time.)", "")
 
@@ -56,7 +57,8 @@ object SwaggerParameterMapper {
         format = format,
         required = defaultValueO.isEmpty,
         default = defaultValueO,
-        enum = enum)
+        enum = enum,
+        description = description)
 
     val enumParamMF: MappingFunction = {
       case JavaEnum(enumConstants)  ⇒ genSwaggerParameter("string", enum = Option(enumConstants))
@@ -117,7 +119,8 @@ object SwaggerParameterMapper {
             mapping.specAsParameter,
             mapping.specAsProperty,
             default = defaultValueO,
-            required = defaultValueO.isEmpty && mapping.required)
+            required = defaultValueO.isEmpty && mapping.required,
+            description = description)
       }
       mf
     }.foldLeft[MappingFunction](PartialFunction.empty)(_ orElse _)

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -71,7 +71,7 @@ object SwaggerParameterMapper {
       GenSwaggerParameter(parameter.name, referenceType = Some(referenceType))
 
     def optionalParam(optionalTpe: String) = {
-      val asRequired = mapParam(parameter.copy(typeName = optionalTpe), modelQualifier = modelQualifier, customMappings = customMappings)
+      val asRequired = mapParam(parameter.copy(typeName = optionalTpe), modelQualifier = modelQualifier, customMappings = customMappings, description = description)
       asRequired.update(required = false, default = asRequired.default)
     }
 

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -360,6 +360,8 @@ final case class SwaggerSpecGenerator(
       else None
     }
 
+    val parameterDescription = descriptionProvider.getMethodParameterDescriptionProvider(route.call)
+
     val paramsFromController = {
       val pathParams = route.path.parts.collect {
         case d: DynamicPart ⇒ d.name
@@ -370,7 +372,7 @@ final case class SwaggerSpecGenerator(
         param ← paramList
         if param.fixed.isEmpty // Removes parameters the client cannot set
       } yield {
-        val description = descriptionProvider.getMethodParamDescription(route.call, paramList, param)
+        val description = parameterDescription(param)
         mapParam(param, modelQualifier, customMappings, description)
       }
 

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -205,8 +205,9 @@ final case class SwaggerSpecGenerator(
         val w = (
           (__ \ 'name).write[String] ~
           (__ \ 'required).write[Boolean] ~
-          (under \ 'default).writeNullable[JsValue])(
-            (c: CustomSwaggerParameter) ⇒ (c.name, c.required, c.default))
+          (under \ 'default).writeNullable[JsValue] ~
+          (__ \ 'description).writeNullable[String])(
+            (c: CustomSwaggerParameter) ⇒ (c.name, c.required, c.default, c.description))
 
         (w.writes(csp) ++ withPrefix(head)) :: tail
       case Nil ⇒ Nil

--- a/core/src/test/scala/com/iheart/playSwagger/DescriptionsSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/DescriptionsSpec.scala
@@ -2,7 +2,7 @@ package com.iheart.playSwagger
 
 import com.iheart.playSwagger.Descriptions.DescriptionProviderImpl
 import org.specs2.mutable.Specification
-import play.routes.compiler.{HandlerCall, Parameter}
+import play.routes.compiler.{ HandlerCall, Parameter }
 
 class DescriptionsSpec extends Specification {
 
@@ -12,7 +12,7 @@ class DescriptionsSpec extends Specification {
     "com.example.FooController.bar(Option[Date])#date" -> "date document 3")
   val descriptionProvider = new DescriptionProviderImpl(descriptionMap)
   "DescriptionProviderImpl" >> {
-    "getMethodParamDescription should use parameterList from HandlerCall." >> {
+    "getMethodParameterDescriptionProvider should use parameterList from HandlerCall." >> {
       val p1 = Parameter("date", "Date", None, None)
       val hc = new HandlerCall(
         "com.example", "FooController", true, "foo", Some(Seq(
@@ -20,7 +20,7 @@ class DescriptionsSpec extends Specification {
       val func = descriptionProvider.getMethodParameterDescriptionProvider(hc)
       func(p1) === Some("date document 1")
     }
-    "getMethodParamDescription should remove package from parameters" >> {
+    "getMethodParameterDescriptionProvider should remove package from parameters" >> {
       val p1 = Parameter("date", "java.time.Date", None, None)
       val hc1 = new HandlerCall(
         "com.example", "FooController", true, "bar", Some(Seq(

--- a/core/src/test/scala/com/iheart/playSwagger/DescriptionsSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/DescriptionsSpec.scala
@@ -1,0 +1,39 @@
+package com.iheart.playSwagger
+
+import com.iheart.playSwagger.Descriptions.DescriptionProviderImpl
+import org.specs2.mutable.Specification
+import play.routes.compiler.{HandlerCall, Parameter}
+
+class DescriptionsSpec extends Specification {
+
+  val descriptionMap = Map(
+    "com.example.FooController.foo(Date)#date" -> "date document 1",
+    "com.example.FooController.bar(Date)#date" -> "date document 2",
+    "com.example.FooController.bar(Option[Date])#date" -> "date document 3")
+  val descriptionProvider = new DescriptionProviderImpl(descriptionMap)
+  "DescriptionProviderImpl" >> {
+    "getMethodParamDescription should use parameterList from HandlerCall." >> {
+      val p1 = Parameter("date", "Date", None, None)
+      val hc = new HandlerCall(
+        "com.example", "FooController", true, "foo", Some(Seq(
+          p1)))
+      val func = descriptionProvider.getMethodParameterDescriptionProvider(hc)
+      func(p1) === Some("date document 1")
+    }
+    "getMethodParamDescription should remove package from parameters" >> {
+      val p1 = Parameter("date", "java.time.Date", None, None)
+      val hc1 = new HandlerCall(
+        "com.example", "FooController", true, "bar", Some(Seq(
+          p1)))
+      val func1 = descriptionProvider.getMethodParameterDescriptionProvider(hc1)
+      func1(p1) === Some("date document 2")
+
+      val p2 = Parameter("date", "Option[java.time.Date]", None, None)
+      val hc2 = new HandlerCall(
+        "com.example", "FooController", true, "bar", Some(Seq(
+          p2)))
+      val func2 = descriptionProvider.getMethodParameterDescriptionProvider(hc2)
+      func2(p2) === Some("date document 3")
+    }
+  }
+}

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
@@ -12,5 +12,6 @@ trait SwaggerKeys {
   val swaggerRoutesFile = SettingKey[String]("swaggerRoutesFile", "the root routes file with which play-swagger start to parse")
   val swaggerOutputTransformers = SettingKey[Seq[String]]("swaggerOutputTransformers", "list of output transformers for processing swagger file")
   val swaggerV3 = SettingKey[Boolean]("swaggerV3", "whether to to produce output compatible with Swagger 3 (also knwon as OpenAPI 3)")
+  val swaggerDescriptionFile = SettingKey[Option[File]]("swaggerDescriptionFile", "The location of a java properties file to supply descriptions for types and parameters.")
   val envOutputTransformer = "com.iheart.playSwagger.EnvironmentVariablesTransformer"
 }

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
@@ -32,6 +32,7 @@ object SwaggerPlugin extends AutoPlugin {
     swaggerFileName := "swagger.json",
     swaggerRoutesFile := "routes",
     swaggerOutputTransformers := Seq(),
+    swaggerDescriptionFile := None,
     swagger := Def.task[File] {
       (swaggerTarget.value).mkdirs()
       val file = swaggerTarget.value / swaggerFileName.value
@@ -40,7 +41,10 @@ object SwaggerPlugin extends AutoPlugin {
         swaggerDomainNameSpaces.value.mkString(",") ::
         swaggerOutputTransformers.value.mkString(",") ::
         swaggerV3.value.toString ::
-        Nil
+        Nil ++ swaggerDescriptionFile.value.map { f ⇒
+          Seq(
+            "--description-file", f.getAbsolutePath)
+        }.getOrElse(Nil)
       val swaggerClasspath = data((fullClasspath in Runtime).value) ++ update.value.select(configurationFilter(swaggerConfig.name))
       toError(runner.value.run("com.iheart.playSwagger.SwaggerSpecRunner", swaggerClasspath, args, streams.value.log))
       file


### PR DESCRIPTION
Hi

I've added the capability to accept descriptions from an external java properties file. The java properties file can be provided either manually or by some other sbt plugins. To companion this change, I've also created a new sbt plugin to extract the description out of the scaladoc of scala source codes. The 2 plugins seem to work nicely and the swagger doc looks more complete now.

Please can you review this PR and let me know what you think ?

Ps. I've also made changes to play2.6 branch, but they are basically the same as the master branch. so I guess I don't have to submit it again ?