### PR TITLE
Readme makes reference to generating the path with ... tags ... - but tags are not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ This allows newly added endpoints to be automatically included in swagger with s
 ```
  ###
  #  summary: create a card 
+ #  tags:
+ #    - Card Endpoints
  #  responses:
  #    200:
  #      description: success


### PR DESCRIPTION
I was also looking for a way to do this and it took me some time to find it, so hopefully putting a tags: example here will help people in my situation