### PR TITLE
Fix race condition.

### DIFF
--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
@@ -50,7 +50,7 @@ object SwaggerPlugin extends AutoPlugin {
       file
     }.value,
     unmanagedResourceDirectories in Assets += swaggerTarget.value,
-    mappings in (Compile, packageBin) += (swaggerTarget.value / swaggerFileName.value) → s"public/${swaggerFileName.value}", //include it in the unmanagedResourceDirectories in Assets doesn't automatically include it package
+    mappings in (Compile, packageBin) += (swagger.value) → s"public/${swaggerFileName.value}", //include it in the unmanagedResourceDirectories in Assets doesn't automatically include it package
     packageBin in Universal := (packageBin in Universal).dependsOn(swagger).value,
     run := (run in Compile).dependsOn(swagger).evaluated,
     stage := stage.dependsOn(swagger).value)


### PR DESCRIPTION
We've observed a race condition where the swagger.json doesn't always get included in our play app.

`mappings in (Compile, packageBin)` doesn't currently depend on the `swagger: TaskKey[File]` that generates the file, so when `packageBin` is invoked, there's no guarantee that the swagger.json file has actually been generated.

Using `swagger.value` instead of `swaggerTarget.value / swaggerFileName.value` should add the explicit dependency on the `swagger` TaskKey so that the file is generated *before* the jar is created.

Might be related to #114.