### PR TITLE
Added spec generation support for parametric types

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
@@ -1,62 +1,100 @@
 package com.iheart.playSwagger
 
+import com.fasterxml.jackson.databind.{ BeanDescription, ObjectMapper }
 import com.iheart.playSwagger.Domain.{ CustomMappings, Definition, GenSwaggerParameter, SwaggerParameter }
 import com.iheart.playSwagger.SwaggerParameterMapper.mapParam
 import play.routes.compiler.Parameter
 
+import scala.collection.JavaConverters
 import scala.reflect.runtime.universe._
 
 final case class DefinitionGenerator(
-  modelQualifier: DomainModelQualifier = PrefixDomainModelQualifier(),
-  mappings:       CustomMappings       = Nil,
-  namingStrategy: NamingStrategy       = NamingStrategy.None)(implicit cl: ClassLoader) {
-
+  modelQualifier:  DomainModelQualifier = PrefixDomainModelQualifier(),
+  mappings:        CustomMappings       = Nil,
+  swaggerPlayJava: Boolean              = false,
+  _mapper:         ObjectMapper         = new ObjectMapper(),
+  namingStrategy:  NamingStrategy       = NamingStrategy.None)(implicit cl: ClassLoader) {
   def dealiasParams(t: Type): Type = {
     appliedType(t.dealias.typeConstructor, t.typeArgs.map { arg ⇒
       dealiasParams(arg.dealias)
     })
   }
 
-  def definition(tpe: Type): Definition = {
-    val fields = tpe.decls.collectFirst {
-      case m: MethodSymbol if m.isPrimaryConstructor ⇒ m
-    }.toList.flatMap(_.paramLists).headOption.getOrElse(Nil)
+  def definition: ParametricType ⇒ Definition = {
+    case parametricType @ ParametricType(tpe, reifiedTypeName, _, _) ⇒
 
-    val properties = fields.map { field ⇒
-      //TODO: find a better way to get the string representation of typeSignature
-      val name = namingStrategy(field.name.decodedName.toString)
-      val typeName = dealiasParams(field.typeSignature).toString
-      // passing None for 'fixed' and 'default' here, since we're not dealing with route parameters
+      val properties = if (swaggerPlayJava) {
+        definitionForPOJO(tpe)
+      } else {
+        val fields = tpe.decls.collectFirst {
+          case m: MethodSymbol if m.isPrimaryConstructor ⇒ m
+        }.toList.flatMap(_.paramLists).headOption.getOrElse(Nil)
+
+        fields.map { field ⇒
+          //TODO: find a better way to get the string representation of typeSignature
+          val name = namingStrategy(field.name.decodedName.toString)
+          val rawTypeName = dealiasParams(field.typeSignature).toString
+          val typeName = parametricType.resolve(rawTypeName)
+          // passing None for 'fixed' and 'default' here, since we're not dealing with route parameters
+          val param = Parameter(name, typeName, None, None)
+          mapParam(param, modelQualifier, mappings)
+        }
+      }
+
+      Definition(
+        name = reifiedTypeName,
+        properties = properties)
+  }
+
+  private def definitionForPOJO(tpe: Type): Seq[Domain.SwaggerParameter] = {
+    val m = runtimeMirror(getClass.getClassLoader)
+    val clazz = m.runtimeClass(tpe.typeSymbol.asClass)
+    val `type` = _mapper.constructType(clazz)
+    val beanDesc: BeanDescription = _mapper.getSerializationConfig.introspect(`type`)
+    val beanProperties = beanDesc.findProperties
+    val ignoreProperties = beanDesc.getIgnoredPropertyNames
+    val propertySet = JavaConverters.asScalaIteratorConverter(beanProperties.iterator()).asScala.toSeq
+    propertySet.filter(bd ⇒ !ignoreProperties.contains(bd.getName)).map { entry ⇒
+      val name = entry.getName
+      val className = entry.getPrimaryMember.getType.getRawClass.getName
+      val generalTypeName = if (entry.getField != null && entry.getField.getType.hasGenericTypes) {
+        val generalType = entry.getField.getType.getContentType.getRawClass.getName
+        s"$className[$generalType]"
+      } else {
+        className
+      }
+      val typeName = if (!entry.isRequired) {
+        s"Option[$generalTypeName]"
+      } else {
+        generalTypeName
+      }
       val param = Parameter(name, typeName, None, None)
       mapParam(param, modelQualifier, mappings)
     }
-
-    Definition(
-      name = tpe.typeSymbol.fullName,
-      properties = properties)
   }
 
-  def definition[T: TypeTag]: Definition = definition(weakTypeOf[T])
+  def definition[T: TypeTag]: Definition = definition(ParametricType[T])
 
-  def definition(className: String): Definition = {
-    val mirror = runtimeMirror(cl)
-    val sym = mirror.staticClass(className)
-    val tpe = sym.selfType
-    definition(tpe)
-  }
+  def definition(className: String): Definition = definition(ParametricType(className))
 
   def allDefinitions(typeNames: Seq[String]): List[Definition] = {
-    def genSwaggerParameter: PartialFunction[SwaggerParameter, GenSwaggerParameter] =
-      { case p: GenSwaggerParameter ⇒ p }
+    def genSwaggerParameter: PartialFunction[SwaggerParameter, GenSwaggerParameter] = {
+      case p: GenSwaggerParameter ⇒ p
+    }
 
     def allReferredDefs(defName: String, memo: List[Definition]): List[Definition] = {
+      def findRefTypes(p: GenSwaggerParameter): Seq[String] =
+        p.referenceType.toSeq ++ {
+          p.items.toSeq.collect(genSwaggerParameter).flatMap(findRefTypes)
+        }
+
       memo.find(_.name == defName) match {
         case Some(_) ⇒ memo
         case None ⇒
           val thisDef = definition(defName)
           val refNames: Seq[String] = for {
             p ← thisDef.properties.collect(genSwaggerParameter)
-            className ← p.referenceType orElse p.items.collect(genSwaggerParameter).flatMap(_.referenceType)
+            className ← findRefTypes(p)
             if modelQualifier.isModel(className)
           } yield className
 
@@ -76,7 +114,15 @@ object DefinitionGenerator {
   def apply(
     domainNameSpace:             String,
     customParameterTypeMappings: CustomMappings,
+    swaggerPlayJava:             Boolean,
     namingStrategy:              NamingStrategy)(implicit cl: ClassLoader): DefinitionGenerator =
     DefinitionGenerator(
-      PrefixDomainModelQualifier(domainNameSpace), customParameterTypeMappings, namingStrategy)
+      PrefixDomainModelQualifier(domainNameSpace), customParameterTypeMappings, swaggerPlayJava, namingStrategy = namingStrategy)
+
+  def apply(
+    domainNameSpace:             String,
+    customParameterTypeMappings: CustomMappings,
+    namingStrategy:              NamingStrategy)(implicit cl: ClassLoader): DefinitionGenerator =
+    DefinitionGenerator(
+      PrefixDomainModelQualifier(domainNameSpace), customParameterTypeMappings, namingStrategy = namingStrategy)
 }

--- a/core/src/main/scala/com/iheart/playSwagger/ParametricType.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/ParametricType.scala
@@ -1,0 +1,44 @@
+package com.iheart.playSwagger
+
+import scala.reflect.runtime.universe._
+import ParametricType._
+
+import scala.collection.immutable.SortedMap
+
+case class ParametricType private (tpe: Type, reifiedTypeName: String, className: String, typeArgsMapping: Map[Line, String]) {
+  val resolve: String ⇒ String = {
+    case ParametricTypeClassName(className, typeArgs) ⇒
+      val resolvedTypes =
+        typeArgs
+          .split(",")
+          .map(_.trim)
+          .map(tn ⇒ typeArgsMapping.getOrElse(tn, resolve(tn)))
+      s"$className[${resolvedTypes.mkString(",")}]"
+    case cn ⇒ typeArgsMapping.getOrElse(cn, cn)
+  }
+}
+
+object ParametricType {
+  final val ParametricTypeClassName = "^(.*?)\\[(.*)\\]$".r
+
+  def apply(reifiedTypeName: String)(implicit cl: ClassLoader): ParametricType = {
+    val mirror = runtimeMirror(cl)
+    reifiedTypeName match {
+      case ParametricTypeClassName(className, typeArgsStr) ⇒
+        val sym = mirror.staticClass(className)
+        val tpe = sym.selfType
+        val typeArgs = typeArgsStr.split(",").map(_.trim).toList
+        val typeArgsMapping = SortedMap(tpe.typeArgs.map(_.toString).zip(typeArgs): _*)
+        ParametricType(tpe, reifiedTypeName, className, typeArgsMapping)
+      case className ⇒
+        val sym = mirror.staticClass(className)
+        val tpe = sym.selfType
+        ParametricType(tpe, className, className, SortedMap.empty)
+    }
+  }
+
+  def apply[T: TypeTag]: ParametricType = {
+    val tpe = implicitly[TypeTag[T]].tpe
+    ParametricType(tpe, tpe.typeSymbol.fullName, tpe.typeSymbol.fullName, Map.empty)
+  }
+}

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -5,14 +5,13 @@ import java.io.File
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.iheart.playSwagger.Domain._
 import com.iheart.playSwagger.OutputTransformer.SimpleOutputTransformer
-import play.api.libs.json._
-import ResourceReader.read
+import com.iheart.playSwagger.ResourceReader.read
+import com.iheart.playSwagger.SwaggerParameterMapper.mapParam
 import org.yaml.snakeyaml.Yaml
-import SwaggerParameterMapper.mapParam
-
-import scala.collection.immutable.ListMap
+import play.api.libs.json._
 import play.routes.compiler._
 
+import scala.collection.immutable.ListMap
 import scala.util.{ Failure, Success, Try }
 
 object SwaggerSpecGenerator {
@@ -37,6 +36,7 @@ object SwaggerSpecGenerator {
   }
 
   case object MissingBaseSpecException extends Exception(s"Missing a $baseSpecFileName.yml or $baseSpecFileName.json to provide base swagger spec")
+
 }
 
 final case class SwaggerSpecGenerator(
@@ -45,8 +45,11 @@ final case class SwaggerSpecGenerator(
   defaultPostBodyFormat: String                 = "application/json",
   outputTransformers:    Seq[OutputTransformer] = Nil,
   swaggerV3:             Boolean                = false,
+  swaggerPlayJava:       Boolean                = false,
   apiVersion:            Option[String]         = None)(implicit cl: ClassLoader) {
-  import SwaggerSpecGenerator.{ customMappingsFileName, baseSpecFileName, MissingBaseSpecException }
+
+  import SwaggerSpecGenerator.{ MissingBaseSpecException, baseSpecFileName, customMappingsFileName }
+
   // routes with their prefix
   type Routes = (String, Seq[Route])
 
@@ -161,7 +164,10 @@ final case class SwaggerSpecGenerator(
         if modelQualifier.isModel(className)
       } yield className
 
-      DefinitionGenerator(modelQualifier, customMappings, namingStrategy).allDefinitions(referredClasses)
+      DefinitionGenerator(
+        modelQualifier = modelQualifier,
+        mappings = customMappings,
+        namingStrategy = namingStrategy).allDefinitions(referredClasses)
     }
 
     val definitionsJson = JsObject(definitions.map(d ⇒ d.name → Json.toJson(d)))

--- a/core/src/test/resources/test.routes
+++ b/core/src/test/resources/test.routes
@@ -74,5 +74,13 @@ POST  /iWantAQueryBody                     controllers.Test.queryBodyHandler(bod
 #      schema:
 #        $ref: '#/definitions/com.iheart.playSwagger.Parent'
 ###
-GET  /iWantAChild                     controllers.Test.queryForChild
+GET  /iWantAChild                           controllers.Test.queryForChild
 
+###
+#  responses:
+#    default:
+#      description: Something optional
+#      schema:
+#        $ref: '#/definitions/com.iheart.playSwagger.TypeParametricWrapper[String, com.iheart.playSwagger.EitherRepr[com.iheart.playSwagger.Cat], Seq[com.iheart.playSwagger.EitherRepr[com.iheart.playSwagger.Dog]]]'
+###
+GET  /iWantVariousStuff                     controllers.Test.queryParametricPolymorphic

--- a/core/src/test/scala/com/iheart/playSwagger/ParametricTypeNamesTransformerSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/ParametricTypeNamesTransformerSpec.scala
@@ -1,0 +1,31 @@
+package com.iheart.playSwagger
+
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+
+import scala.util.Success
+
+class ParametricTypeNamesTransformerSpec extends Specification {
+  private val transformer = new ParametricTypeNamesTransformer
+
+  transformer.getClass.getSimpleName >> {
+    "transform parametrized declaration into RFC-3986 compliant URI identifiers" >> {
+      transformer {
+        Json.obj(
+          "$ref" -> "#/components/schemas/some.class.Name[SomeType, another.ClassName]",
+          "types" -> Json.obj(
+            "another.class.Name[String, Seq[Option[Int]]]" -> 3,
+            "arrField" -> Json.arr(
+              "1" -> "should.not.be.replaced.ClassName[String]",
+              "2" -> "should.not.be.replaced.ClassName[Int]")))
+      } === Success(
+        Json.obj(
+          "$ref" -> "#/components/schemas/some.class.Name-SomeType_another.ClassName",
+          "types" -> Json.obj(
+            "another.class.Name-String_Seq-Option-Int" -> 3,
+            "arrField" -> Json.arr(
+              "1" -> "should.not.be.replaced.ClassName[String]",
+              "2" -> "should.not.be.replaced.ClassName[Int]"))))
+    }
+  }
+}

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -16,7 +16,7 @@ object Publish {
       "git@github.com:iheartradio/play-swagger.git")),
     pomIncludeRepository := { _ ⇒ false },
     publishArtifact in Test := false,
-    releaseProcess :=  Seq[ReleaseStep](
+    releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
       inquireVersions,
       releaseStepCommandAndRemaining("+clean"),
@@ -27,8 +27,7 @@ object Publish {
       releaseStepCommandAndRemaining("+publish"),
       setNextVersion,
       commitNextVersion,
-      pushChanges)
-  )
+      pushChanges))
 
   val sbtPluginSettings = Seq(
     licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
@@ -31,7 +31,7 @@ object SwaggerPlugin extends AutoPlugin {
     swaggerTarget := target.value / "swagger",
     swaggerFileName := "swagger.json",
     swaggerRoutesFile := "routes",
-    swaggerOutputTransformers := Seq(),
+    swaggerOutputTransformers := Seq("com.iheart.playSwagger.ParametricTypeNamesTransformer"),
     swaggerAPIVersion := version.value,
     swaggerPrettyJson := false,
     swaggerNamingStrategy := "none",


### PR DESCRIPTION
Support for generic typed case classes added. Now, one can have request/response schema names that reference a class whose constructor arguments have parameterized types. Example:
```
package models

case class Foo[T](payload: T)
case class AnotherOne(someString: String)
```
Now you can reference the schema of a response/request directly with `models.Foo[models.AnotherOne]` and a correct OpenAPI 3 spec will be generated (not tested with Swagger 2.0):
```
###
#   summary: Get a message
#   responses:
#       200:
#           description: success
#           content:
#               application/json:
#                   schema:
#                       $ref: '#/components/schemas/models.Foo[models.AnotherOne]'
###
GET     /message                    controllers.AsyncController.parametric
```

The generated schema name, however, cannot contain `[`, `]` or `,` which appear in type argument lists in Scala. Therefore, I've added a default `OutputTransformer` (`ParametricTypeNamesTransformerSpec`) which _normalises_ the name into the URL-compliant form. The definitions output would then look like:
```
{
  "components" : {
    "schemas" : {
      "models.AnotherOne" : {
        "properties" : {
          "someString" : {
            "type" : "string"
          }
        },
        "required" : [ "someString" ]
      },
      "models.Foo-models.AnotherOne" : {
        "properties" : {
          "payload" : {
            "$ref" : "#/components/schemas/models.AnotherOne"
          }
        },
        "required" : [ "payload" ]
      }
    }
  },
  "openapi" : "3.0.0",
  "paths" : {
    "/message" : {
      "get" : {
        "summary" : "Get a message",
        "operationId" : "parametric",
        "responses" : {
          "200" : {
            "description" : "success",
            "content" : {
              "application/json" : {
                "schema" : {
                  "$ref" : "#/components/schemas/models.Foo-models.AnotherOne"
                }
              }
            }
          }
        },
        "tags" : [ "routes" ]
      }
    }
  },
  ...
}
```