### PR TITLE
Basic support for Refined

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ lazy val playSwagger = project.in(file("core"))
       Dependencies.playRoutesCompiler ++
       Dependencies.playJson ++
       Dependencies.enumeratum ++
+      Dependencies.refined ++
       Dependencies.test ++
       Dependencies.yaml,
     scalaVersion := "2.12.8",

--- a/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
@@ -32,7 +32,11 @@ final case class DefinitionGenerator(
       fields.map { field ⇒
         //TODO: find a better way to get the string representation of typeSignature
         val name = namingStrategy(field.name.decodedName.toString)
-        val typeName = dealiasParams(field.typeSignature).toString
+        val typeName = dealiasParams(field.typeSignature).toString match {
+          case "eu.timepit.refined.api.Refined" => field.info.dealias.typeArgs.head.toString
+          case v  => v
+        }
+
         // passing None for 'fixed' and 'default' here, since we're not dealing with route parameters
         val param = Parameter(name, typeName, None, None)
         mapParam(param, modelQualifier, mappings)

--- a/core/src/test/scala/com/iheart/playSwagger/RefinedTypes.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/RefinedTypes.scala
@@ -1,0 +1,13 @@
+package com.iheart.playSwagger
+
+import eu.timepit.refined._
+import eu.timepit.refined.api._
+import eu.timepit.refined.boolean.And
+import eu.timepit.refined.collection.MinSize
+import eu.timepit.refined.numeric._
+import eu.timepit.refined.string._
+
+object RefinedTypes {
+  type SpotifyAccount = String Refined And[MinSize[W.`6`.T], MatchesRegex[W.`"""@?(\\w){1,15}"""`.T]]
+  type Age = Int Refined Positive
+}

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -1,11 +1,12 @@
 package com.iheart.playSwagger
 
-import com.iheart.playSwagger.Domain.{ CustomTypeMapping, CustomMappings }
+import com.iheart.playSwagger.Domain.{CustomMappings, CustomTypeMapping}
+import com.iheart.playSwagger.RefinedTypes.{Age, SpotifyAccount}
 import org.specs2.mutable.Specification
 import play.api.libs.json._
 
 case class Track(name: String, genre: Option[String], artist: Artist, related: Seq[Artist], numbers: Seq[Int])
-case class Artist(name: String, age: Int)
+case class Artist(name: String, age: Age, spotifyAccount: SpotifyAccount)
 
 case class Student(name: String, teacher: Option[Teacher])
 case class Teacher(name: String)
@@ -171,6 +172,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     "read definition from referenced referenceTypes" >> {
 
       (artistDefJson \ "properties" \ "age" \ "type").as[String] === "integer"
+      (artistDefJson \ "properties" \ "spotifyAccount" \ "type").as[String] === "string"
     }
 
     "read trait with container" >> {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,7 @@ object Dependencies {
     val playJson = "2.8.1"
     val specs2 = "4.6.0"
     val enumeratum = "1.5.13"
+    val refined = "0.9.14"
   }
 
   val playTest = Seq(
@@ -22,6 +23,9 @@ object Dependencies {
 
   val enumeratum = Seq(
     "com.beachape" %% "enumeratum" % Versions.enumeratum % Test)
+
+  val refined = Seq(
+    "eu.timepit" %% "refined" % Versions.refined % Test)
 
   val test = Seq(
     "org.specs2" %% "specs2-core" % Versions.specs2 % "test",


### PR DESCRIPTION
Fixes #326

Now you can define your refined types and Play Swagger will consider the `T` of the `Refined[T, P]` as the type parameter.