### PR TITLE
Update swagger-ui dependency in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Alternatively you can use swagger-ui webjar and have you play app serving the sw
 
 Add the following dependency
 ```scala
-libraryDependencies += "org.webjars" % "swagger-ui" % "2.2.0"
+libraryDependencies += "org.webjars" % "swagger-ui" % "3.35.0"
 ```
 
 Add the following to your route file


### PR DESCRIPTION
Using OpenAPI 3.0 will not work with the version 2.2.0. Using 2.2.0 with OpenAPI 3.0 will lead into "fetching resource list" error when opening the swagger page