### PR TITLE
Update example project plugin version to 0.10.3-SNAPSHOT

### DIFF
--- a/example/project/plugins.sbt
+++ b/example/project/plugins.sbt
@@ -3,6 +3,6 @@ addSbtPlugin("com.typesafe.play" %% "sbt-plugin" % "2.8.0")
 
 
 // play swagger plugin
-addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.10.1-SNAPSHOT")
+addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.10.3-SNAPSHOT")
 
 


### PR DESCRIPTION
Fixes the `play2.8` branch, which is currently broken in CI as the example project is referencing an older version.