### PR TITLE
Update Publish.scala for Sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val playSwagger = project.in(file("core"))
 
 lazy val sbtPlaySwagger = project.in(file("sbtPlugin"))
   .settings(
-    Publish.sbtPluginSettings,
+    Publish.coreSettings,
     Format.settings,
     addSbtPlugin("com.typesafe.sbt" %% "sbt-native-packager" % "1.3.17" % Provided),
     addSbtPlugin("com.typesafe.sbt" %% "sbt-web" % "1.4.3" % Provided))

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -38,9 +38,4 @@ object Publish {
       ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
       pushChanges))
 
-
-  val sbtPluginSettings = Seq(
-    licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
-    publishMavenStyle := false
-  )
 }

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -1,12 +1,12 @@
+import com.typesafe.sbt.pgp.PgpKeys
 import sbt._, Keys._
-import bintray.BintrayKeys._
 import sbtrelease.ReleasePlugin.autoImport._
 import ReleaseTransformations._
+
 object Publish {
 
   val coreSettings = Seq(
-    bintrayOrganization := Some("iheartradio"),
-    bintrayPackageLabels := Seq("play-framework", "swagger", "rest-api", "API", "documentation"),
+    organization in ThisBuild := "com.iheart",
     publishMavenStyle := true,
     licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
     homepage := Some(url("http://iheartradio.github.io/play-swagger")),
@@ -15,22 +15,32 @@ object Publish {
       "git@github.com:iheartradio/play-swagger.git")),
     pomIncludeRepository := { _ ⇒ false },
     publishArtifact in Test := false,
+    publishTo := {
+      val nexus = "https://oss.sonatype.org/"
+      if (isSnapshot.value)
+        Some("Snapshots" at nexus + "content/repositories/snapshots")
+      else
+        Some("Releases" at nexus + "service/local/staging/deploy/maven2")
+    },
+    releaseCrossBuild := true,
+    releasePublishArtifactsAction := PgpKeys.publishSigned.value,
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,
       inquireVersions,
-      releaseStepCommandAndRemaining("+clean"),
-      releaseStepCommandAndRemaining("+test"),
+      runClean,
+      runTest,
       setReleaseVersion,
       commitReleaseVersion,
       tagRelease,
-      releaseStepCommandAndRemaining("+publish"),
+      publishArtifacts,
       setNextVersion,
       commitNextVersion,
+      ReleaseStep(action = Command.process("sonatypeReleaseAll", _)),
       pushChanges))
 
 
   val sbtPluginSettings = Seq(
     licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.html")),
-    publishMavenStyle := false,
-    bintrayOrganization := Some("iheartradio"))
+    publishMavenStyle := false
+  )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2-1")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
 


### PR DESCRIPTION
Per issue #365, a shot at copying relevant configuration from ficus to allow publishing to Sonatype.