### PR TITLE
Use the right class loader instance for Java

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
@@ -57,7 +57,7 @@ final case class DefinitionGenerator(
   }
 
   private def definitionForPOJO(tpe: Type): Seq[Domain.SwaggerParameter] = {
-    val m = runtimeMirror(getClass.getClassLoader)
+    val m = runtimeMirror(cl)
     val clazz = m.runtimeClass(tpe.typeSymbol.asClass)
     val `type` = _mapper.constructType(clazz)
     val beanDesc: BeanDescription = _mapper.getSerializationConfig.introspect(`type`)


### PR DESCRIPTION
When generating docs programmatically using Java, the wrong class loader instance is referenced leaving the beans unfindable.

See https://github.com/haitelfatmi/play-swagger/commit/92eea7bc1044f2bac3b856d9b9bbf8799e847744