### PR TITLE
Refactor: Introduce Scalafix and Lint / Refactor the code

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -21,6 +21,9 @@ jobs:
     - name: Check Format by scalafmt
       run:
         sbt scalafmtSbtCheck scalafmtCheckAll
+    - name: Check Lint by scalafix
+      run:
+        sbt scalafixEnable "scalafixAll --check"
     - name: Sbt Plugin tests
       run: 
         sbt clean sbtPlaySwagger/scripted
@@ -29,4 +32,4 @@ jobs:
         sbt ';project playSwagger;clean;+test'
     - name: Example compile
       run: 
-        cd example && sbt clean scalafmtSbtCheck scalafmtCheckAll compile
+        cd example && sbt clean scalafmtSbtCheck scalafmtCheckAll scalafixEnable "scalafixAll --check" compile

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,27 @@
+rules = [
+  RemoveUnused
+  NoAutoTupling
+  NoValInForComprehension
+  ProcedureSyntax
+  ExplicitResultTypes
+  OrganizeImports
+]
+
+RemoveUnused {
+  imports = true
+  privates = false
+  locals = true
+  patternvars = true
+  params = false
+}
+
+OrganizeImports {
+  coalesceToWildcardImportThreshold = 6
+  groupedImports = Merge
+  groups = [
+    "re:javax?\\."
+    "scala.",
+    "*",
+    "com.sun."
+  ]
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,9 @@
 organization in ThisBuild := "com.iheart"
 
+scalafixDependencies in ThisBuild ++= Seq(
+  "com.github.liancheng" %% "organize-imports" % "0.6.0"
+)
+
 lazy val noPublishSettings = Seq(
   skip in publish := true,
   publish := (),
@@ -32,7 +36,11 @@ lazy val playSwagger = project.in(file("core"))
       Dependencies.test ++
       Dependencies.yaml,
     scalaVersion := scalaV,
-    crossScalaVersions := Seq(scalaVersion.value, "2.13.6")
+    crossScalaVersions := Seq(scalaVersion.value, "2.13.6"),
+    scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 13)) => Seq("-Wunused")
+      case _ => Seq("-Xlint:unused")
+    })
   )
 
 lazy val sbtPlaySwagger = project.in(file("sbtPlugin"))
@@ -55,5 +63,9 @@ lazy val sbtPlaySwagger = project.in(file("sbtPlugin"))
       scriptedLaunchOpts.value ++
         Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
     },
-    scriptedBufferLog := false
+    scriptedBufferLog := false,
+    scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 13)) => Seq("-Wunused")
+      case _ => Seq("-Xlint:unused")
+    })
   )

--- a/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
@@ -1,12 +1,12 @@
 package com.iheart.playSwagger
 
+import scala.collection.JavaConverters
+import scala.reflect.runtime.universe._
+
 import com.fasterxml.jackson.databind.{BeanDescription, ObjectMapper}
 import com.iheart.playSwagger.Domain.{CustomMappings, Definition, GenSwaggerParameter, SwaggerParameter}
 import com.iheart.playSwagger.SwaggerParameterMapper.mapParam
 import play.routes.compiler.Parameter
-
-import scala.collection.JavaConverters
-import scala.reflect.runtime.universe._
 
 final case class DefinitionGenerator(
     modelQualifier: DomainModelQualifier = PrefixDomainModelQualifier(),

--- a/core/src/main/scala/com/iheart/playSwagger/Domain.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/Domain.scala
@@ -1,7 +1,6 @@
 package com.iheart.playSwagger
 
 import play.api.libs.json.{JsObject, JsPath, JsValue, Reads}
-import play.twirl.api.TemplateMagic.Default
 
 object Domain {
   type Path = String
@@ -34,7 +33,7 @@ object Domain {
       items: Option[SwaggerParameter] = None,
       enum: Option[Seq[String]] = None
   ) extends SwaggerParameter {
-    def update(_required: Boolean, _nullable: Boolean, _default: Option[JsValue]) =
+    def update(_required: Boolean, _nullable: Boolean, _default: Option[JsValue]): GenSwaggerParameter =
       copy(required = _required, nullable = Some(_nullable), default = _default)
   }
 
@@ -46,7 +45,7 @@ object Domain {
       nullable: Option[Boolean] = None,
       default: Option[JsValue] = None
   ) extends SwaggerParameter {
-    def update(_required: Boolean, _nullable: Boolean, _default: Option[JsValue]) =
+    def update(_required: Boolean, _nullable: Boolean, _default: Option[JsValue]): CustomSwaggerParameter =
       copy(required = _required, nullable = Some(_nullable), default = _default)
   }
 

--- a/core/src/main/scala/com/iheart/playSwagger/OutputTransformer.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/OutputTransformer.scala
@@ -1,10 +1,10 @@
 package com.iheart.playSwagger
 
-import com.iheart.playSwagger.OutputTransformer.SimpleOutputTransformer
-import play.api.libs.json.{JsArray, JsString, JsValue, JsObject}
-
 import scala.util.matching.Regex
-import scala.util.{Success, Failure, Try}
+import scala.util.{Failure, Success, Try}
+
+import com.iheart.playSwagger.OutputTransformer.SimpleOutputTransformer
+import play.api.libs.json.{JsArray, JsObject, JsString, JsValue}
 
 /** Specialization of a Kleisli function (A => M[B]) */
 trait OutputTransformer extends (JsObject ⇒ Try[JsObject]) {
@@ -57,7 +57,7 @@ object OutputTransformer {
 
 class PlaceholderVariablesTransformer(map: String ⇒ Option[String], pattern: Regex = "^\\$\\{(.*)\\}$".r)
     extends OutputTransformer {
-  def apply(value: JsObject) = OutputTransformer.traverseTransformer(value) {
+  def apply(value: JsObject): Try[JsObject] = OutputTransformer.traverseTransformer(value) {
     case JsString(pattern(key)) ⇒ map(key) match {
         case Some(result) ⇒ Success(JsString(result))
         case None ⇒ Failure(new IllegalStateException(s"Unable to find variable $key"))

--- a/core/src/main/scala/com/iheart/playSwagger/ParametricType.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/ParametricType.scala
@@ -1,9 +1,10 @@
 package com.iheart.playSwagger
 
-import scala.reflect.runtime.universe._
-import ParametricType._
-
 import scala.collection.immutable.SortedMap
+import scala.reflect.runtime.universe._
+import scala.util.matching.Regex
+
+import ParametricType._
 
 case class ParametricType private (
     tpe: Type,
@@ -24,7 +25,7 @@ case class ParametricType private (
 }
 
 object ParametricType {
-  final val ParametricTypeClassName = "^(.*?)\\[(.*)\\]$".r
+  final val ParametricTypeClassName: Regex = "^(.*?)\\[(.*)\\]$".r
 
   def apply(reifiedTypeName: String)(implicit cl: ClassLoader): ParametricType = {
     val mirror = runtimeMirror(cl)

--- a/core/src/main/scala/com/iheart/playSwagger/ResourceReader.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/ResourceReader.scala
@@ -1,8 +1,9 @@
 package com.iheart.playSwagger
 
 import java.io.{IOException, InputStream}
-import scala.util.{Failure, Try}
+
 import scala.io.Source
+import scala.util.{Failure, Try}
 
 object ResourceReader {
 

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -1,11 +1,12 @@
 package com.iheart.playSwagger
 
+import scala.reflect.runtime.universe
+import scala.util.Try
+import scala.util.matching.Regex
+
 import com.iheart.playSwagger.Domain.{CustomMappings, CustomSwaggerParameter, GenSwaggerParameter, SwaggerParameter}
 import play.api.libs.json._
 import play.routes.compiler.Parameter
-
-import scala.reflect.runtime.universe
-import scala.util.Try
 
 object SwaggerParameterMapper {
 
@@ -164,7 +165,7 @@ object SwaggerParameterMapper {
   }
 
   implicit class CaseInsensitiveRegex(sc: StringContext) {
-    def ci = ("(?i)" + sc.parts.mkString).r
+    def ci: Regex = ("(?i)" + sc.parts.mkString).r
   }
 
   /**

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -2,6 +2,10 @@ package com.iheart.playSwagger
 
 import java.io.File
 
+import scala.collection.immutable.ListMap
+import scala.collection.mutable
+import scala.util.{Failure, Success, Try}
+
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.iheart.playSwagger.Domain._
 import com.iheart.playSwagger.OutputTransformer.SimpleOutputTransformer
@@ -10,10 +14,6 @@ import com.iheart.playSwagger.SwaggerParameterMapper.mapParam
 import org.yaml.snakeyaml.Yaml
 import play.api.libs.json._
 import play.routes.compiler._
-
-import scala.collection.mutable
-import scala.collection.immutable.ListMap
-import scala.util.{Failure, Success, Try}
 
 object SwaggerSpecGenerator {
   private val marker = "##"

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
@@ -2,9 +2,9 @@ package com.iheart.playSwagger
 
 import java.nio.file.{Files, Paths, StandardOpenOption}
 
-import play.api.libs.json.{JsValue, Json}
-
 import scala.util.{Failure, Success, Try}
+
+import play.api.libs.json.{JsValue, Json}
 
 object SwaggerSpecRunner extends App {
   implicit def cl: ClassLoader = getClass.getClassLoader

--- a/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
@@ -49,13 +49,13 @@ object MyObject {
 }
 
 object ExcludingDomainQualifier extends DomainModelQualifier {
-  val parent = PrefixDomainModelQualifier("com.iheart.playSwagger")
-  val exclusions = Seq("com.iheart.playSwagger.DictType")
+  val parent: PrefixDomainModelQualifier = PrefixDomainModelQualifier("com.iheart.playSwagger")
+  val exclusions: Seq[String] = Seq("com.iheart.playSwagger.DictType")
   override def isModel(className: String): Boolean = parent.isModel(className) && !(exclusions contains className)
 }
 
 class DefinitionGeneratorSpec extends Specification {
-  implicit val cl = getClass.getClassLoader
+  implicit val cl: ClassLoader = getClass.getClassLoader
 
   "definition" >> {
 

--- a/core/src/test/scala/com/iheart/playSwagger/OutputTransformerSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/OutputTransformerSpec.scala
@@ -1,10 +1,10 @@
 package com.iheart.playSwagger
 
+import scala.util.{Failure, Success}
+
 import com.iheart.playSwagger.OutputTransformer.SimpleOutputTransformer
 import org.specs2.mutable.Specification
 import play.api.libs.json._
-
-import scala.util.{Failure, Success}
 
 class OutputTransformerSpec extends Specification {
   "OutputTransformer.traverseTransformer" >> {
@@ -124,7 +124,7 @@ class EnvironmentVariablesSpec extends Specification {
 }
 
 class EnvironmentVariablesIntegrationSpec extends Specification {
-  implicit val cl = getClass.getClassLoader
+  implicit val cl: ClassLoader = getClass.getClassLoader
 
   "integration" >> {
     "generate api with placeholders in place" >> {

--- a/core/src/test/scala/com/iheart/playSwagger/ParametricTypeNamesTransformerSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/ParametricTypeNamesTransformerSpec.scala
@@ -1,9 +1,9 @@
 package com.iheart.playSwagger
 
+import scala.util.Success
+
 import org.specs2.mutable.Specification
 import play.api.libs.json.Json
-
-import scala.util.Success
 
 class ParametricTypeNamesTransformerSpec extends Specification {
   private val transformer = new ParametricTypeNamesTransformer

--- a/core/src/test/scala/com/iheart/playSwagger/RefinedTypes.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/RefinedTypes.scala
@@ -1,13 +1,13 @@
 package com.iheart.playSwagger
 
+import scala.collection.immutable
+
 import eu.timepit.refined._
 import eu.timepit.refined.api._
 import eu.timepit.refined.boolean.And
 import eu.timepit.refined.collection.{MinSize, NonEmpty}
 import eu.timepit.refined.numeric._
 import eu.timepit.refined.string._
-
-import scala.collection.immutable
 
 object RefinedTypes {
   type SpotifyAccount = String Refined And[MinSize[W.`6`.T], MatchesRegex[W.`"""@?(\\w){1,15}"""`.T]]

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -1,8 +1,8 @@
 package com.iheart.playSwagger
 
-import org.specs2.mutable.Specification
-import play.api.libs.json.{Json, JsString}
 import com.iheart.playSwagger.Domain._
+import org.specs2.mutable.Specification
+import play.api.libs.json.{JsString, Json}
 import play.routes.compiler.Parameter
 
 class SwaggerParameterMapperSpec extends Specification {

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -1,9 +1,9 @@
 package com.iheart.playSwagger
 
-import com.iheart.playSwagger.Domain.{CustomMappings, CustomTypeMapping}
-import com.iheart.playSwagger.RefinedTypes.{Age, Albums, SpotifyAccount}
-
 import java.time.LocalDate
+
+import com.iheart.playSwagger.Domain.CustomMappings
+import com.iheart.playSwagger.RefinedTypes.{Age, Albums, SpotifyAccount}
 import org.specs2.mutable.Specification
 import play.api.libs.json._
 
@@ -40,8 +40,8 @@ case class Cat(catName: String)
 case class TypeParametricWrapper[T, O, S](simplePayload: T, maybeOtherPayload: Option[O], seq: Seq[S])
 
 class SwaggerSpecGeneratorSpec extends Specification {
-  implicit val cl = getClass.getClassLoader
-  val gen = SwaggerSpecGenerator()
+  implicit val cl: ClassLoader = getClass.getClassLoader
+  val gen: SwaggerSpecGenerator = SwaggerSpecGenerator()
 
   "full path" >> {
     "combine routePath with prefix" >> {
@@ -98,7 +98,7 @@ class SwaggerSpecGeneratorSpec extends Specification {
 }
 
 class SwaggerSpecGeneratorIntegrationSpec extends Specification {
-  implicit val cl = getClass.getClassLoader
+  implicit val cl: ClassLoader = getClass.getClassLoader
 
   "integration" >> {
 

--- a/example/.scalafix.conf
+++ b/example/.scalafix.conf
@@ -1,0 +1,1 @@
+../.scalafix.conf

--- a/example/app/Filters.scala
+++ b/example/app/Filters.scala
@@ -1,9 +1,8 @@
 import javax.inject._
-import play.api._
-import play.api.http.HttpFilters
-import play.api.mvc._
 
 import filters.ExampleFilter
+import play.api._
+import play.api.http.HttpFilters
 
 /**
   * This class configures filters that run on every request. This
@@ -24,7 +23,7 @@ class Filters @Inject() (
     exampleFilter: ExampleFilter
 ) extends HttpFilters {
 
-  override val filters = {
+  override val filters: Seq[ExampleFilter] = {
     // Use the example filter if we're running development mode. If
     // we're running in production or test mode then don't use any
     // filters at all.

--- a/example/app/Module.scala
+++ b/example/app/Module.scala
@@ -1,6 +1,6 @@
-import com.google.inject.AbstractModule
 import java.time.Clock
 
+import com.google.inject.AbstractModule
 import services.{ApplicationTimer, AtomicCounter, Counter}
 
 /**
@@ -15,7 +15,7 @@ import services.{ApplicationTimer, AtomicCounter, Counter}
   */
 class Module extends AbstractModule {
 
-  override def configure() = {
+  override def configure(): Unit = {
     // Use the system clock as the default implementation of Clock
     bind(classOf[Clock]).toInstance(Clock.systemDefaultZone)
     // Ask Guice to create an instance of ApplicationTimer when the

--- a/example/app/controllers/AsyncController.scala
+++ b/example/app/controllers/AsyncController.scala
@@ -1,13 +1,14 @@
 package controllers
 
-import akka.actor.ActorSystem
 import javax.inject._
-import models.Message
-import play.api._
-import play.api.libs.json.Json
-import play.api.mvc._
-import scala.concurrent.{ExecutionContext, Future, Promise}
+
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future, Promise}
+
+import akka.actor.ActorSystem
+import models.Message
+import play.api.libs.json.{Json, OFormat}
+import play.api.mvc._
 
 /**
   * This controller creates an `Action` that demonstrates how to write
@@ -22,7 +23,7 @@ import scala.concurrent.duration._
 @Singleton
 class AsyncController @Inject() (actorSystem: ActorSystem, components: ControllerComponents)(implicit
 exec: ExecutionContext) extends AbstractController(components) {
-  implicit val fmt = Json.format[Message]
+  implicit val fmt: OFormat[Message] = Json.format[Message]
 
   /**
     * Create an Action that returns a plain text message after a delay
@@ -32,7 +33,7 @@ exec: ExecutionContext) extends AbstractController(components) {
     * will be called when the application receives a `GET` request with
     * a path of `/message`.
     */
-  def message = Action.async {
+  def message: Action[AnyContent] = Action.async {
     getFutureMessage(1.second).map { msg ⇒ Ok(Json.toJson(msg)) }
   }
 

--- a/example/app/controllers/HomeController.scala
+++ b/example/app/controllers/HomeController.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import javax.inject._
-import play.api._
+
 import play.api.mvc._
 
 /**
@@ -17,7 +17,7 @@ class HomeController @Inject() (components: ControllerComponents) extends Abstra
     * will be called when the application receives a `GET` request with
     * a path of `/`.
     */
-  def index = Action {
+  def index: Action[AnyContent] = Action {
     Ok(views.html.index("Your new application is ready."))
   }
 

--- a/example/app/controllers/math/CountController.scala
+++ b/example/app/controllers/math/CountController.scala
@@ -20,6 +20,6 @@ class CountController @Inject() (counter: Counter, components: ControllerCompone
     * count. The result is plain text. This `Action` is mapped to
     * `GET /count` requests by an entry in the `routes` config file.
     */
-  def count = Action { Ok(counter.nextCount().toString) }
+  def count: Action[AnyContent] = Action { Ok(counter.nextCount().toString) }
 
 }

--- a/example/app/filters/ExampleFilter.scala
+++ b/example/app/filters/ExampleFilter.scala
@@ -1,9 +1,11 @@
 package filters
 
-import akka.stream.Materializer
 import javax.inject._
-import play.api.mvc._
+
 import scala.concurrent.{ExecutionContext, Future}
+
+import akka.stream.Materializer
+import play.api.mvc._
 
 /**
   * This is a simple filter that adds a header to all requests. It's

--- a/example/app/services/ApplicationTimer.scala
+++ b/example/app/services/ApplicationTimer.scala
@@ -2,9 +2,11 @@ package services
 
 import java.time.{Clock, Instant}
 import javax.inject._
+
+import scala.concurrent.Future
+
 import play.api.Logger
 import play.api.inject.ApplicationLifecycle
-import scala.concurrent.Future
 
 /**
   * This class demonstrates how to run code when the
@@ -23,7 +25,7 @@ import scala.concurrent.Future
 @Singleton
 class ApplicationTimer @Inject() (clock: Clock, appLifecycle: ApplicationLifecycle) {
 
-  val logger = Logger(this.getClass)
+  val logger: Logger = Logger(this.getClass)
 
   // This code is called when the application starts.
   private val start: Instant = clock.instant

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -2,6 +2,10 @@ name := """example"""
 
 version := "1.0-SNAPSHOT"
 
+scalafixDependencies in ThisBuild ++= Seq(
+  "com.github.liancheng" %% "organize-imports" % "0.6.0"
+)
+
 lazy val root = (project in file(".")).enablePlugins(PlayScala, SwaggerPlugin) //enable plugin
 
 scalaVersion := "2.12.14"
@@ -14,5 +18,7 @@ libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.0.0" % Test,
   "org.webjars" % "swagger-ui" % "2.2.0" // play-swagger ui integration
 )
+
+scalacOptions ++= Seq("-Xlint:unused")
 
 swaggerDomainNameSpaces := Seq("models")

--- a/example/project/plugins.sbt
+++ b/example/project/plugins.sbt
@@ -3,5 +3,7 @@ addSbtPlugin("com.typesafe.play" %% "sbt-plugin" % "2.8.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")
+
 // play swagger plugin
 addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.10.8-SNAPSHOT")

--- a/example/test/ApplicationSpec.scala
+++ b/example/test/ApplicationSpec.scala
@@ -1,7 +1,7 @@
 import org.scalatestplus.play._
-import play.api.test._
-import play.api.test.Helpers._
 import org.scalatestplus.play.guice.GuiceOneAppPerTest
+import play.api.test.Helpers._
+import play.api.test._
 
 /**
   * Add your spec here.

--- a/example/test/IntegrationSpec.scala
+++ b/example/test/IntegrationSpec.scala
@@ -1,6 +1,4 @@
 import org.scalatestplus.play._
-import play.api.test._
-import play.api.test.Helpers._
 import org.scalatestplus.play.guice.GuiceOneServerPerTest
 
 /**

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,5 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.7")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
@@ -5,28 +5,29 @@ import java.io.File
 import sbt.{SettingKey, TaskKey}
 
 trait SwaggerKeys {
-  val swagger = TaskKey[File]("swagger", "generates the swagger API documentation")
-  val swaggerDomainNameSpaces =
+  val swagger: TaskKey[File] = TaskKey[File]("swagger", "generates the swagger API documentation")
+  val swaggerDomainNameSpaces: SettingKey[Seq[String]] =
     SettingKey[Seq[String]]("swaggerDomainNameSpaces", "swagger domain namespaces for model classes")
-  val swaggerTarget =
+  val swaggerTarget: SettingKey[File] =
     SettingKey[File]("swaggerTarget", "the location of the swagger documentation in your packaged app.")
-  val swaggerFileName =
+  val swaggerFileName: SettingKey[String] =
     SettingKey[String]("swaggerFileName", "the swagger filename the swagger documentation in your packaged app.")
-  val swaggerRoutesFile =
+  val swaggerRoutesFile: SettingKey[String] =
     SettingKey[String]("swaggerRoutesFile", "the root routes file with which play-swagger start to parse")
-  val swaggerOutputTransformers =
+  val swaggerOutputTransformers: SettingKey[Seq[String]] =
     SettingKey[Seq[String]]("swaggerOutputTransformers", "list of output transformers for processing swagger file")
-  val swaggerV3 =
+  val swaggerV3: SettingKey[Boolean] =
     SettingKey[Boolean]("swaggerV3", "whether to to produce output compatible with Swagger 3 (also knwon as OpenAPI 3)")
   val envOutputTransformer = "com.iheart.playSwagger.EnvironmentVariablesTransformer"
 
-  val swaggerAPIVersion = SettingKey[String]("swaggerAPIVersion", "Version of the API")
+  val swaggerAPIVersion: SettingKey[String] = SettingKey[String]("swaggerAPIVersion", "Version of the API")
 
-  val swaggerPrettyJson =
+  val swaggerPrettyJson: SettingKey[Boolean] =
     SettingKey[Boolean]("swaggerPrettyJson", "True, if needs to pretty print Swagger's documentation")
 
-  val swaggerPlayJava =
+  val swaggerPlayJava: SettingKey[Boolean] =
     SettingKey[Boolean]("swaggerPlayJava", "True, if use play java and use jackson to generate model schema")
 
-  val swaggerNamingStrategy = SettingKey[String]("swaggerNamingStrategy", "Naming strategy to decode case class fields")
+  val swaggerNamingStrategy: SettingKey[String] =
+    SettingKey[String]("swaggerNamingStrategy", "Naming strategy to decode case class fields")
 }

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
@@ -2,13 +2,13 @@ package com.iheart.sbtPlaySwagger
 
 import com.typesafe.sbt.packager.archetypes.JavaAppPackaging
 import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport._
+import com.typesafe.sbt.web.Import._
 import sbt.Attributed._
 import sbt.Keys._
 import sbt.{AutoPlugin, _}
-import com.typesafe.sbt.web.Import._
 
 object SwaggerPlugin extends AutoPlugin {
-  lazy val SwaggerConfig = config("play-swagger").hide
+  lazy val SwaggerConfig: Configuration = config("play-swagger").hide
   lazy val playSwaggerVersion = com.iheart.playSwagger.BuildInfo.version
 
   object autoImport extends SwaggerKeys


### PR DESCRIPTION
Look after this because of the dependencies of the pr: https://github.com/iheartradio/play-swagger/pull/462

[scalafix](https://scalacenter.github.io/scalafix/) is a Linter and refactoring tool designed for Scala.
It can automatically respond to compiler warnings by introducing some useful settings such as import alignment.
The rules described here only work with Scala 2.12 series, but you can use them for various code conditions if you try hard enough. (e.g. The rules I have: https://github.com/pixiv/scalafix-pixiv-rule)

Although this tool is slower than scalafmt, we ask that you consider it, as its introduction would improve the development experience 🙇 