### PR TITLE
Include multiple $ref'd swagger files

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,57 @@ Also, for `$ref` fields you will want to prefix paths with `#/components/schemas
 POST   /tracks       controller.Api.createTrack()
 ```
 
+#### No #definitions generated when referencing other Swagger files
+
+By placing a json or YAML file in `conf/${dir}/${file}` and referencing it with `$ref` in a comment, the file can be generated embedded in swagger.json.
+
+example `conf/routes` file.
+
+```
+###
+#  summary: Top Page
+#  responses:
+#    200:
+#      $ref: './swagger/home_200.yml'
+###
+GET     /            controllers.HomeController.index
+```
+
+example `conf/swagger/home_200.yml` file.
+
+```yaml
+description: success
+```
+
+Of course, writing `schema` etc. will also be embedded.
+
+Generated `swagger.json`.
+
+```json
+{
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "index",
+        "tags": [
+          "routes"
+        ],
+        "summary": "Top Page",
+        "responses": {
+          "200": {
+            "description": "success"
+          }
+        }
+      }
+    }
+  }
+  ......
+}
+```
+
+See the following document for information on how to refer to other files by "$ref".
+
+https://swagger.io/docs/specification/using-ref/
 
 #### Is play java supported? 
 

--- a/core/src/main/scala/com/iheart/playSwagger/PathValidator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/PathValidator.scala
@@ -1,0 +1,14 @@
+package com.iheart.playSwagger
+
+import java.nio.file.{InvalidPathException, Paths}
+
+object PathValidator {
+  def isValid(path: String): Boolean = {
+    try {
+      Paths.get(path)
+      true
+    } catch {
+      case _: InvalidPathException | _: NullPointerException => false
+    }
+  }
+}

--- a/core/src/test/resources/subjects.routes
+++ b/core/src/test/resources/subjects.routes
@@ -1,0 +1,6 @@
+###
+#  responses:
+#    200:
+#      $ref: './swagger/subject_dow_200.yml'
+###
+GET     /dow/:subject               controllers.Subjects.dayOfWeek(subject: com.iheart.playSwagger.Subject)

--- a/core/src/test/resources/swagger/subject_dow_200.yml
+++ b/core/src/test/resources/swagger/subject_dow_200.yml
@@ -1,0 +1,9 @@
+description: success
+content:
+  application/json:
+    schema:
+      $ref: '#/definitions/com.iheart.playSwagger.DayOfWeek'
+    example:
+      success:
+        value:
+          name: "MonDay"

--- a/core/src/test/resources/test.routes
+++ b/core/src/test/resources/test.routes
@@ -4,6 +4,7 @@
 ->   /api/resource         resource.Routes
 ->   /api/customResource   customResource.Routes
 ->   /api/students         students.Routes
+->   /api/subjects         subjects.Routes
 
 ->   /level1               level1.Routes
 

--- a/example/conf/routes
+++ b/example/conf/routes
@@ -1,5 +1,10 @@
 
-### NoDocs ###
+###
+#  summary: Top Page
+#  responses:
+#    200:
+#      $ref: './swagger/home_200.yml'
+###
 GET     /                           controllers.HomeController.index
 
 ->      /math                       math.Routes

--- a/example/conf/swagger/home_200.yml
+++ b/example/conf/swagger/home_200.yml
@@ -1,0 +1,1 @@
+description: success


### PR DESCRIPTION
In my project, the `routes` file is long and there is a lot of content in each document that I would like to see in the Swagger UI.
I tried to include the response document in another file, referring to [Using $ref](https://swagger.io/docs/specification/using-ref/), but the `#definitions` were not generated properly.
So we created a function to embed the JSON or YAML file in the project referenced by `$ref`.
Please check the `README` for the specific changes.

I thought about just scanning an external file and generating `#definitions`, but I thought it would be more convenient to have an embedding function, considering that I need to make a good reference to the main `swagger.json`.