### PR TITLE
Feat: Comments to skip multiple endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,20 @@ e.g.
 GET   /docs/swagger-ui/*file        controllers.Assets.at(path:String="/public/lib/swagger-ui", file:String)
 ```
 
+Multiple lines can be skipped.
+
+※NoDocsEnd must always be listed directly before one line as a comment on <b>the endpoint not to be skipped</b>, or on the last line of the routes fill.
+
+```
+### NoDocsStart ###
+GET      /api/hidden/a                 controllers.hiddenEndPointA()
+
+GET      /api/hidden/b                 controllers.hiddenEndPointB()
+
+### NoDocsEnd ###
+GET      /api/hidden/c                 controllers.hiddenEndPointC()
+```
+
 #### How to specify body content in a POST endpoint 
 Body content is specified as a special parameter in swagger. So you need to create a parameter in your swagger spec comment as "body", for example
 ```

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -404,7 +404,13 @@ final case class SwaggerSpecGenerator(
 
   private def paths(routes: Seq[Route], prefix: String, tag: Option[Tag]): JsObject = {
     JsObject {
-      val endPointEntries = routes.flatMap(route ⇒ endPointEntry(route, prefix, tag))
+      val endPointEntries = routes.foldLeft[(Seq[(String, JsObject)], Boolean)]((Nil, false)) {
+        case ((o, skipping), route) ⇒
+          endPointEntry(route, prefix, tag, skipping) match {
+            case (Some(route), skipping) => (o :+ route, skipping)
+            case (None, skipping) => (o, skipping)
+          }
+      }._1
 
       // maintain the routes order as per the original routing file
       val zgbp = endPointEntries.zipWithIndex.groupBy(_._1._1)
@@ -415,19 +421,35 @@ final case class SwaggerSpecGenerator(
     }
   }
 
-  private def endPointEntry(route: Route, prefix: String, tag: Option[String]): Option[(String, JsObject)] = {
+  private def endPointEntry(
+      route: Route,
+      prefix: String,
+      tag: Option[String],
+      skipping: Boolean
+  ): (Option[(String, JsObject)], Boolean) = {
     import SwaggerSpecGenerator.marker
 
     val comments = route.comments.map(_.comment).mkString("\n")
+
     if (s"$marker\\s*NoDocs\\s*$marker".r.findFirstIn(comments).isDefined) {
-      None
+      (None, skipping)
+    } else if (s"$marker\\s*NoDocsStart\\s*$marker".r.findFirstIn(comments).isDefined) {
+      // NoDocsStart ならスキップを開始する
+      (None, true)
     } else {
-      val inRoutePath = route.path.parts.map {
-        case DynamicPart(name, _, _) ⇒ s"{$name}"
-        case StaticPart(value) ⇒ value
-      }.mkString
-      val method = route.verb.value.toLowerCase
-      Some(fullPath(prefix, inRoutePath) → Json.obj(method → endPointSpec(route, tag)))
+      val docsEnd = s"$marker\\s*NoDocsEnd\\s*$marker".r.findFirstIn(comments).isDefined
+      // スキップ中かつ、 NoDocsEnd が指定されていないならスキップする
+      if (!docsEnd && skipping) {
+        (None, skipping)
+      } else {
+        // それ以外はスキップしない
+        val inRoutePath = route.path.parts.map {
+          case DynamicPart(name, _, _) ⇒ s"{$name}"
+          case StaticPart(value) ⇒ value
+        }.mkString
+        val method = route.verb.value.toLowerCase
+        (Some(fullPath(prefix, inRoutePath) → Json.obj(method → endPointSpec(route, tag))), false)
+      }
     }
   }
 

--- a/core/src/test/resources/liveMeta.routes
+++ b/core/src/test/resources/liveMeta.routes
@@ -36,3 +36,11 @@ POST     /api/station/playedTracks             controllers.LiveMeta.addPlayedTra
 
 ### NoDocs ###
 GET      /api/station/hidden                   controllers.LiveMeta.hiddenEndPoint()
+
+### NoDocsStart ###
+GET      /api/station/hidden/a                 controllers.LiveMeta.hiddenEndPointA()
+
+GET      /api/station/hidden/b                 controllers.LiveMeta.hiddenEndPointB()
+
+### NoDocsEnd ###
+GET      /api/station/hidden/c                 controllers.LiveMeta.hiddenEndPointC()

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -295,7 +295,19 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     }
 
     "does not generate for end points marked as hidden" >> {
-      (pathJson \ "/api/station/hidden" \ "get").toOption must beEmpty
+      "single" >> {
+        (pathJson \ "/api/station/hidden" \ "get").toOption must beEmpty
+      }
+      "multiple-a" >> {
+        (pathJson \ "/api/station/hidden/a" \ "get").toOption must beEmpty
+      }
+      "multiple-b" >> {
+        (pathJson \ "/api/station/hidden/b" \ "get").toOption must beEmpty
+      }
+    }
+
+    "does generate for end points marked as finished hidden" >> {
+      (pathJson \ "/api/station/hidden/c" \ "get").toOption must not(beEmpty)
     }
 
     "generate path correctly with missing type (String by default) in controller description" >> {


### PR DESCRIPTION
In my product, web pages and API endpoints live together, so I need to include so many "### NoDocs ###".
To avoid this, I created a feature that allows multiple endpoints to be ignored by using "### NoDocsStart ###" and "### NoDocsEnd ###".

e.g.

```
### NoDocsStart ###
GET      /api/hidden/a                 controllers.hiddenEndPointA()
GET      /api/hidden/b                 controllers.hiddenEndPointB()
### NoDocsEnd ###
GET      /api/hidden/c                 controllers.hiddenEndPointC()
```