### PR TITLE
feat: Mix in top-level $ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,8 @@ POST   /tracks       controller.Api.createTrack()
 
 By placing a json or YAML file in `conf/${dir}/${file}` and referencing it with `$ref` in a comment, the file can be generated embedded in swagger.json.
 
+⚠️ **Warning**: If a file that does not exist in `/conf` is specified, or if a typo is used for the filename, `$ref:"${filename}"` will be output as is.
+
 example `conf/routes` file.
 
 ```
@@ -450,7 +452,7 @@ GET     /            controllers.HomeController.index
 example `conf/swagger/home_200.yml` file.
 
 ```yaml
-description: success
+description: "success"
 ```
 
 Of course, writing `schema` etc. will also be embedded.
@@ -482,6 +484,27 @@ Generated `swagger.json`.
 See the following document for information on how to refer to other files by "$ref".
 
 https://swagger.io/docs/specification/using-ref/
+
+##### You can also cut out the entire comment.
+
+This feature is very useful, but OpenAPI does not allow top-level `$ref`, so failing to embed it may result in an invalid `swagger.json`!
+
+```
+###
+#  $ref: './swagger/home.yml'
+###
+GET     /            controllers.HomeController.index
+```
+
+example `home.yml` file.
+
+```yaml
+summary: Top Page
+  responses:
+    200:
+      description: "success"
+```
+
 
 #### Is play java supported? 
 

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -1,9 +1,11 @@
 package com.iheart.playSwagger
 
 import java.io.File
+
 import scala.collection.immutable.ListMap
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
+
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.iheart.playSwagger.Domain._
 import com.iheart.playSwagger.OutputTransformer.SimpleOutputTransformer
@@ -445,7 +447,9 @@ final case class SwaggerSpecGenerator(
   private def endPointSpec(route: Route, tag: Option[String]) = {
 
     def tryParseYaml(comment: String): Option[JsObject] = {
-      val pattern = "^\\w+:".r
+      // The purpose here is more to ensure that it is not in other formats such as JSON
+      // If invalid YAML is passed, org.yaml.snakeyaml.parser.ParserException
+      val pattern = "^\\w+|\\$ref:".r
       pattern.findFirstIn(comment).map(_ ⇒ parseYaml[JsObject](comment))
     }
 

--- a/core/src/test/resources/subjects.routes
+++ b/core/src/test/resources/subjects.routes
@@ -4,3 +4,9 @@
 #      $ref: './swagger/subject_dow_200.yml'
 ###
 GET     /dow/:subject               controllers.Subjects.dayOfWeek(subject: com.iheart.playSwagger.Subject)
+
+###
+#  $ref: './swagger/subject_dow_not.yml'
+#  description: 'What day of the week is that subject?'
+###
+GET     /dow/not/:subject           controllers.Subjects.hasNotDayOfWeek(subject: com.iheart.playSwagger.Subject)

--- a/core/src/test/resources/swagger/subject_dow_not.yml
+++ b/core/src/test/resources/swagger/subject_dow_not.yml
@@ -1,0 +1,13 @@
+responses:
+  200:
+    description: "success"
+    content:
+      application/json:
+        schema:
+          $ref: '#/definitions/com.iheart.playSwagger.DayOfWeek'
+        example:
+          success:
+            value:
+              name: "MonDay"
+  400:
+    description: "error"

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -498,10 +498,12 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
 
     "parse mixin referenced external file" >> {
       lazy val subjectJson = (pathJson \ "/api/subjects/dow/{subject}" \ "get").as[JsObject]
+
       "parse param" >> {
         val properties = (definitionsJson \ "com.iheart.playSwagger.Subject" \ "properties").as[JsObject]
         (properties \ "name" \ "type").as[String] === "string"
       }
+
       "embedding mixed responses" >> {
         "description" >> {
           (subjectJson \ "responses" \ "200" \ "description").as[String] === "success"
@@ -510,6 +512,24 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
           (subjectJson \ "responses" \ "200" \ "content" \ "application/json" \ "schema" \ "$ref").as[String] ===
             "#/definitions/com.iheart.playSwagger.DayOfWeek"
         }
+      }
+    }
+
+    "Top-level $ref is also embedded" >> {
+      lazy val subjectNotJson = (pathJson \ "/api/subjects/dow/not/{subject}" \ "get").as[JsObject]
+
+      "Information written in comments is mixed with external files" >> {
+        (subjectNotJson \ "description").as[String] === "What day of the week is that subject?"
+      }
+      "description_200" >> {
+        (subjectNotJson \ "responses" \ "200" \ "description").as[String] === "success"
+      }
+      "description_400" >> {
+        (subjectNotJson \ "responses" \ "400" \ "description").as[String] === "error"
+      }
+      "reference schema" >> {
+        (subjectNotJson \ "responses" \ "200" \ "content" \ "application/json" \ "schema" \ "$ref").as[String] ===
+          "#/definitions/com.iheart.playSwagger.DayOfWeek"
       }
     }
 


### PR DESCRIPTION
By #467, we can mix in a top-level "$ref" in the following format.

```scala
###
#  description: "description"
#  $ref: './swagger/subject_dow_200.yml'
###
```

However, if "$ref" is defined at the top or that is all, no embedding was done.

With this change, the entire comment can now be cut out as a single file.