### PR TITLE
build: add scalafix-pixiv-rule in scalafix

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -5,6 +5,11 @@ rules = [
   ProcedureSyntax
   ExplicitResultTypes
   OrganizeImports
+  UnnecessarySemicolon
+  ZeroIndexToHead
+  CheckIsEmpty
+  NonCaseException
+  SingleConditionMatch
 ]
 
 RemoveUnused {

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,8 @@
 organization in ThisBuild := "com.iheart"
 
 scalafixDependencies in ThisBuild ++= Seq(
-  "com.github.liancheng" %% "organize-imports" % "0.6.0"
+  "com.github.liancheng" %% "organize-imports" % "0.6.0",
+  "net.pixiv" %% "scalafix-pixiv-rule" % "2.2.0"
 )
 
 lazy val noPublishSettings = Seq(

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -3,7 +3,8 @@ name := """example"""
 version := "1.0-SNAPSHOT"
 
 scalafixDependencies in ThisBuild ++= Seq(
-  "com.github.liancheng" %% "organize-imports" % "0.6.0"
+  "com.github.liancheng" %% "organize-imports" % "0.6.0",
+  "net.pixiv" %% "scalafix-pixiv-rule" % "2.2.0"
 )
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, SwaggerPlugin) //enable plugin


### PR DESCRIPTION
The scalafix rules I am running are now compatible with Scala 2.12 and I would like to introduce them.
After running it, I have not found any bad code for this pattern at this time, but it would help me to accept future pull requests.

https://github.com/pixiv/scalafix-pixiv-rule