### PR TITLE
feat: comments that can be skipped in a file at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,23 @@ e.g.
 GET   /docs/swagger-ui/*file        controllers.Assets.at(path:String="/public/lib/swagger-ui", file:String)
 ```
 
+##### Skip entire file
+
+The entire file can be skipped by adding `### SkipFileForDocs ###` at the beginning of the routes file.
+
+Alternatively, the routes file can be split into multiple files, so that you can skip practically only a part of the file.
+
+https://www.playframework.com/documentation/ja/2.4.x/SBTSubProjects
+
+```
+### SkipFileForDocs ###
+
+GET      /api/hidden/a                 controllers.hiddenEndPointA()
+GET      /api/hidden/b                 controllers.hiddenEndPointB()
+GET      /api/hidden/c                 controllers.hiddenEndPointC()
+```
+
+
 #### How to specify body content in a POST endpoint 
 Body content is specified as a special parameter in swagger. So you need to create a parameter in your swagger spec comment as "body", for example
 ```

--- a/core/src/test/resources/hidden.route
+++ b/core/src/test/resources/hidden.route
@@ -1,0 +1,7 @@
+### SkipFileForDocs ###
+
+GET      a                 controllers.LiveMeta.hiddenEndPointA()
+
+GET      b                 controllers.LiveMeta.hiddenEndPointB()
+
+GET      c                 controllers.LiveMeta.hiddenEndPointC()

--- a/core/src/test/resources/liveMeta.routes
+++ b/core/src/test/resources/liveMeta.routes
@@ -36,3 +36,5 @@ POST     /api/station/playedTracks             controllers.LiveMeta.addPlayedTra
 
 ### NoDocs ###
 GET      /api/station/hidden                   controllers.LiveMeta.hiddenEndPoint()
+
+-> /api/station/hidden hidden.Routes

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -295,7 +295,20 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     }
 
     "does not generate for end points marked as hidden" >> {
-      (pathJson \ "/api/station/hidden" \ "get").toOption must beEmpty
+      "single" >> {
+        (pathJson \ "/api/station/hidden" \ "get").toOption must beEmpty
+      }
+      "can batch skip within a file" >> {
+        "multiple-a" >> {
+          (pathJson \ "/api/station/hidden/a" \ "get").toOption must beEmpty
+        }
+        "multiple-b" >> {
+          (pathJson \ "/api/station/hidden/b" \ "get").toOption must beEmpty
+        }
+        "multiple-c" >> {
+          (pathJson \ "/api/station/hidden/c" \ "get").toOption must beEmpty
+        }
+      }
     }
 
     "generate path correctly with missing type (String by default) in controller description" >> {


### PR DESCRIPTION
Created based on discussion of #469

You can completely ignore the file by placing `### SkipFileForDocs ###` at the beginning of the file like this.

```
### SkipFileForDocs ###

GET      /api/hidden/a                 controllers.hiddenEndPointA()
GET      /api/hidden/b                 controllers.hiddenEndPointB()
GET      /api/hidden/c                 controllers.hiddenEndPointC()
```

Looking at [SBTSubProjects](https://www.playframework.com/documentation/ja/2.4.x/SBTSubProjects), the `routes` file splitting seemed to be a feature for subprojects, but it actually works, so it may be useful for semantic file splitting.

`/conf/routes`: 

```
GET /index                  controllers.Application.index()

->  /admin admin.Routes

GET     /assets/*file       controllers.Assets.at(path="/public", file)
```

`/conf/admin.routes`

```
GET /index                  controllers.admin.Application.index()

GET /assets/*file           controllers.admin.Assets.at(path="/public/lib/myadmin", file)
```