### PR TITLE
feat: Include the controller name in the operation ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,14 @@ summary: Top Page
       description: "success"
 ```
 
+#### Duplicate operationId?
+
+It can be configured in `build.sbt`. 
+This setting allows you to set the `${controllerName}.${methodName}` to name the operationId.
+
+```
+swaggerOperationIdNamingFully := true
+```
 
 #### Is play java supported? 
 

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -517,7 +517,7 @@ final case class SwaggerSpecGenerator(
     val parameterJson = if (mergedParams.value.nonEmpty) Json.obj("parameters" → mergedParams) else Json.obj()
 
     val operationId = Json.obj(
-      "operationId" → route.call.method
+      "operationId" → s"${route.call.controller}.${route.call.method}"
     )
 
     val rawPathJson = operationId ++ tag.fold(Json.obj()) { t ⇒

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -38,8 +38,14 @@ object SwaggerSpecGenerator {
     )
   }
 
-  def apply(swaggerV3: Boolean, domainNameSpaces: String*)(implicit cl: ClassLoader): SwaggerSpecGenerator = {
-    SwaggerSpecGenerator(NamingStrategy.None, PrefixDomainModelQualifier(domainNameSpaces: _*), swaggerV3 = swaggerV3)
+  def apply(swaggerV3: Boolean, operationIdFully: Boolean, domainNameSpaces: String*)(implicit
+  cl: ClassLoader): SwaggerSpecGenerator = {
+    SwaggerSpecGenerator(
+      NamingStrategy.None,
+      PrefixDomainModelQualifier(domainNameSpaces: _*),
+      swaggerV3 = swaggerV3,
+      operationIdFully = operationIdFully
+    )
   }
   def apply(outputTransformers: Seq[OutputTransformer], domainNameSpaces: String*)(implicit
   cl: ClassLoader): SwaggerSpecGenerator = {
@@ -62,7 +68,8 @@ final case class SwaggerSpecGenerator(
     outputTransformers: Seq[OutputTransformer] = Nil,
     swaggerV3: Boolean = false,
     swaggerPlayJava: Boolean = false,
-    apiVersion: Option[String] = None
+    apiVersion: Option[String] = None,
+    operationIdFully: Boolean = false
 )(implicit cl: ClassLoader) {
 
   import SwaggerSpecGenerator.{MissingBaseSpecException, baseSpecFileName, customMappingsFileName}
@@ -517,7 +524,7 @@ final case class SwaggerSpecGenerator(
     val parameterJson = if (mergedParams.value.nonEmpty) Json.obj("parameters" → mergedParams) else Json.obj()
 
     val operationId = Json.obj(
-      "operationId" → s"${route.call.controller}.${route.call.method}"
+      "operationId" → (if (operationIdFully) s"${route.call.controller}.${route.call.method}" else route.call.method)
     )
 
     val rawPathJson = operationId ++ tag.fold(Json.obj()) { t ⇒

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
@@ -9,11 +9,12 @@ import play.api.libs.json.{JsValue, Json}
 object SwaggerSpecRunner extends App {
   implicit def cl: ClassLoader = getClass.getClassLoader
 
-  val targetFile :: routesFile :: domainNameSpaceArgs :: outputTransformersArgs :: swaggerV3String :: apiVersion :: swaggerPrettyJson :: swaggerPlayJavaString :: namingStrategy :: Nil =
+  val targetFile :: routesFile :: domainNameSpaceArgs :: outputTransformersArgs :: swaggerV3String :: apiVersion :: swaggerPrettyJson :: swaggerPlayJavaString :: namingStrategy :: operationIdNamingFullyString :: Nil =
     args.toList
   private def fileArg = Paths.get(targetFile)
   private def swaggerJson = {
     val swaggerV3 = java.lang.Boolean.parseBoolean(swaggerV3String)
+    val swaggerOperationIdNamingFully = java.lang.Boolean.parseBoolean(operationIdNamingFullyString)
     val swaggerPlayJava = java.lang.Boolean.parseBoolean(swaggerPlayJavaString)
     val domainModelQualifier = PrefixDomainModelQualifier(domainNameSpaceArgs.split(","): _*)
     val transformersStrs: Seq[String] = if (outputTransformersArgs.isEmpty) Seq() else outputTransformersArgs.split(",")
@@ -34,7 +35,8 @@ object SwaggerSpecRunner extends App {
       outputTransformers = transformers,
       swaggerV3 = swaggerV3,
       swaggerPlayJava = swaggerPlayJava,
-      apiVersion = Some(apiVersion)
+      apiVersion = Some(apiVersion),
+      operationIdFully = swaggerOperationIdNamingFully
     ).generate(routesFile).get
 
     if (swaggerPrettyJson.toBoolean) Json.prettyPrint(swaggerSpec)

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -672,7 +672,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     }
 
     "add operation ids" >> {
-      (addTrackJson \ "operationId").as[String] ==== "addPlayedTracks"
+      (addTrackJson \ "operationId").as[String] ==== "LiveMeta.addPlayedTracks"
     }
 
     "should maintain route file order" >> {

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -113,7 +113,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
       (json \ "paths" \ "/player/{pid}/context/{bid}").asOpt[JsObject] must beSome
     }
 
-    lazy val json = SwaggerSpecGenerator(false, "com.iheart").generate("test.routes").get
+    lazy val json = SwaggerSpecGenerator(false, false, "com.iheart").generate("test.routes").get
     lazy val pathJson = json \ "paths"
     lazy val definitionsJson = json \ "definitions"
     lazy val postBodyJson = (pathJson \ "/post-body" \ "post").as[JsObject]
@@ -671,7 +671,13 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
       required.value must contain(JsString("keeper"))
     }
 
-    "add operation ids" >> {
+    "add operation id" >> {
+      (addTrackJson \ "operationId").as[String] ==== "addPlayedTracks"
+    }
+
+    "fully operation id" >> {
+      lazy val json = SwaggerSpecGenerator(false, true, "com.iheart").generate("test.routes").get
+      lazy val addTrackJson = (json \ "paths" \ "/api/station/playedTracks" \ "post").as[JsObject]
       (addTrackJson \ "operationId").as[String] ==== "LiveMeta.addPlayedTracks"
     }
 
@@ -705,7 +711,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
   }
 
   "integration v3" >> {
-    lazy val json = SwaggerSpecGenerator(true, "com.iheart").generate("testV3.routes").get
+    lazy val json = SwaggerSpecGenerator(true, false, "com.iheart").generate("testV3.routes").get
     lazy val componentSchemasJson = json \ "components" \ "schemas"
     lazy val trackJson = (componentSchemasJson \ "com.iheart.playSwagger.Track").as[JsObject]
 

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
@@ -30,4 +30,10 @@ trait SwaggerKeys {
 
   val swaggerNamingStrategy: SettingKey[String] =
     SettingKey[String]("swaggerNamingStrategy", "Naming strategy to decode case class fields")
+
+  val swaggerOperationIdNamingFully: SettingKey[Boolean] =
+    SettingKey[Boolean](
+      "swaggerOperationIdNaming",
+      "Either use the operationId of the generated json as the method name"
+    )
 }

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
@@ -9,7 +9,7 @@ import sbt.{AutoPlugin, _}
 
 object SwaggerPlugin extends AutoPlugin {
   lazy val SwaggerConfig: Configuration = config("play-swagger").hide
-  lazy val playSwaggerVersion = com.iheart.playSwagger.BuildInfo.version
+  lazy val playSwaggerVersion: String = com.iheart.playSwagger.BuildInfo.version
 
   object autoImport extends SwaggerKeys
 
@@ -36,6 +36,7 @@ object SwaggerPlugin extends AutoPlugin {
     swaggerPrettyJson := false,
     swaggerPlayJava := false,
     swaggerNamingStrategy := "none",
+    swaggerOperationIdNamingFully := false,
     swagger := Def.task[File] {
       (swaggerTarget.value).mkdirs()
       val file = swaggerTarget.value / swaggerFileName.value
@@ -48,6 +49,7 @@ object SwaggerPlugin extends AutoPlugin {
         swaggerPrettyJson.value.toString ::
         swaggerPlayJava.value.toString ::
         swaggerNamingStrategy.value.toString ::
+        swaggerOperationIdNamingFully.value.toString ::
         Nil
       val swaggerClasspath =
         data((fullClasspath in Runtime).value) ++ update.value.select(configurationFilter(SwaggerConfig.name))

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
@@ -31,7 +31,7 @@ TaskKey[Unit]("check") := {
       |   "paths":{
       |      "/tracks/{trackId}":{
       |         "get":{
-      |           "operationId":"versioned",
+      |           "operationId":"Assets.versioned",
       |            "tags":[
       |               "${swaggerRoutesFile.value}"
       |            ],
@@ -126,20 +126,20 @@ TaskKey[Unit]("check") := {
       |      }
       |   ]
       |}
-    """.stripMargin)
+    """.stripMargin
+  )
 
   val result = uniform(IO.read(swaggerTarget.value / swaggerFileName.value))
-
 
   if (result != expected) {
     val rs = result.split('\n')
     val ep = expected.split('\n')
     val compare = rs.zip(ep).map {
       case (resultLine, expectedLine) =>
-        if(resultLine != expectedLine)
+        if (resultLine != expectedLine)
           "DIFF >>>>>>>>>>>\n" +
-          s"Result > $resultLine\n" +
-          s"Expect < $expectedLine"
+            s"Result > $resultLine\n" +
+            s"Expect < $expectedLine"
         else
           s"Result > $resultLine"
     }.mkString("\n")
@@ -152,7 +152,8 @@ TaskKey[Unit]("check") := {
 
          >>>>> extra expected lines:
          $left
-       """.stripMargin)
+       """.stripMargin
+    )
   }
 }
 

--- a/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
+++ b/sbtPlugin/src/sbt-test/sbt-play-swagger/generate-docs/build.sbt
@@ -31,7 +31,7 @@ TaskKey[Unit]("check") := {
       |   "paths":{
       |      "/tracks/{trackId}":{
       |         "get":{
-      |           "operationId":"Assets.versioned",
+      |           "operationId":"versioned",
       |            "tags":[
       |               "${swaggerRoutesFile.value}"
       |            ],
@@ -126,20 +126,20 @@ TaskKey[Unit]("check") := {
       |      }
       |   ]
       |}
-    """.stripMargin
-  )
+    """.stripMargin)
 
   val result = uniform(IO.read(swaggerTarget.value / swaggerFileName.value))
+
 
   if (result != expected) {
     val rs = result.split('\n')
     val ep = expected.split('\n')
     val compare = rs.zip(ep).map {
       case (resultLine, expectedLine) =>
-        if (resultLine != expectedLine)
+        if(resultLine != expectedLine)
           "DIFF >>>>>>>>>>>\n" +
-            s"Result > $resultLine\n" +
-            s"Expect < $expectedLine"
+          s"Result > $resultLine\n" +
+          s"Expect < $expectedLine"
         else
           s"Result > $resultLine"
     }.mkString("\n")
@@ -152,8 +152,7 @@ TaskKey[Unit]("check") := {
 
          >>>>> extra expected lines:
          $left
-       """.stripMargin
-    )
+       """.stripMargin)
   }
 }
 


### PR DESCRIPTION
In play-swagger, operationId is generated from the controller method name.

As far as the swagger documentation is concerned, the `operationId` must be unique.
https://swagger.io/docs/specification/paths-and-operations/

Method names are unique within the namespace of the package / class, but there is usually more than one controller class.


For the moment, `"${className}. ${methodName}"` to define the `operationId`, but this is very BREAKING.
**Should we maintain backward compatibility by making it selectable in the plugin options?**

**Also, redundant to me, but if you care about essential uniqueness, you need `route.call.packageName`!**

@kailuowang 
I would love to get some advice on specifications!
