### PR TITLE
feat: Define a mode in `NamingStorategy` to skip `_` before a number

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ To use a custom naming strategies to override your case classes field names, you
 
 ```scala
 //default is 'none', which is your camelCased case class
-swaggerNamingStrategy := "snake_case" //kebab-case, lowercase and UpperCamelCase also available
+swaggerNamingStrategy := "snake_case" //snake_case_skip_number, kebab-case, lowercase and UpperCamelCase also available
 ```
 
 #### The spec is missing when built to a docker image using sbt-native-pakcager

--- a/core/src/main/scala/com/iheart/playSwagger/NamingStrategy.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/NamingStrategy.scala
@@ -8,6 +8,7 @@ sealed abstract class NamingStrategy(f: String ⇒ String) extends (String ⇒ S
 
 object NamingStrategy {
   val regex: Regex = "[A-Z\\d]".r
+  val skipNumberRegex: Regex = "[A-Z]".r
 
   object None extends NamingStrategy(identity)
   object SnakeCase extends NamingStrategy(x ⇒ regex.replaceAllIn(x, { m ⇒ "_" + m.group(0).toLowerCase() }))
@@ -17,9 +18,13 @@ object NamingStrategy {
         val (head, tail) = x.splitAt(1)
         head.toUpperCase() + tail
       })
+  object SnakeCaseSkipNumber extends NamingStrategy(x =>
+        skipNumberRegex.replaceAllIn(x, { m => "_" + m.group(0).toLowerCase() })
+      )
 
   def from(naming: String): NamingStrategy = naming match {
     case "snake_case" ⇒ SnakeCase
+    case "snake_case_skip_number" => SnakeCaseSkipNumber
     case "kebab-case" ⇒ KebabCase
     case "lowercase" ⇒ LowerCase
     case "UpperCamelCase" ⇒ UpperCamelCase

--- a/core/src/test/scala/com/iheart/playSwagger/NamingStrategySpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/NamingStrategySpec.scala
@@ -12,6 +12,10 @@ class NamingStrategySpec extends Specification {
       NamingStrategy.from("snake_case")("attributeName") must equalTo("attribute_name")
     }
 
+    "snake_case_skip_number" >> {
+      NamingStrategy.from("snake_case_skip_number")("attributeName1") must equalTo("attribute_name1")
+    }
+
     "kebab-case" >> {
       NamingStrategy.from("kebab-case")("attributeName") must equalTo("attribute-name")
     }

--- a/example/project/plugins.sbt
+++ b/example/project/plugins.sbt
@@ -6,4 +6,4 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.1")
 
 // play swagger plugin
-addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.12.1-SNAPSHOT")
+addSbtPlugin("com.iheart" % "sbt-play-swagger" % "0.12.2-SNAPSHOT")


### PR DESCRIPTION
It has been a while.
I am using snake case for parameter names in my project. In particular, names like `value1` (≠ `value_1`) are used a lot.

There are several identified discussions about the treatment of numbers in the snake case, such as https://github.com/rubocop/ruby-style-guide/issues/606.
We believe that the current policy of the `"snake_case"` Storategy is correct for snake cases, but we would like an option for those who do not want to insert an underscore before a number.