### PR TITLE
style: Eliminate right arrows marked with Unicode characters (Use ->, =>)

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,4 +1,5 @@
 rules = [
+  UnifiedArrow
   RemoveUnused
   NoAutoTupling
   NoValInForComprehension

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization in ThisBuild := "com.iheart"
 
 scalafixDependencies in ThisBuild ++= Seq(
   "com.github.liancheng" %% "organize-imports" % "0.6.0",
-  "net.pixiv" %% "scalafix-pixiv-rule" % "2.2.0"
+  "net.pixiv" %% "scalafix-pixiv-rule" % "2.4.0"
 )
 
 lazy val noPublishSettings = Seq(

--- a/core/src/main/scala/com/iheart/playSwagger/NamingStrategy.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/NamingStrategy.scala
@@ -2,7 +2,7 @@ package com.iheart.playSwagger
 
 import scala.util.matching.Regex
 
-sealed abstract class NamingStrategy(f: String ⇒ String) extends (String ⇒ String) {
+sealed abstract class NamingStrategy(f: String => String) extends (String => String) {
   override def apply(keyName: String): String = f(keyName)
 }
 
@@ -11,10 +11,10 @@ object NamingStrategy {
   val skipNumberRegex: Regex = "[A-Z]".r
 
   object None extends NamingStrategy(identity)
-  object SnakeCase extends NamingStrategy(x ⇒ regex.replaceAllIn(x, { m ⇒ "_" + m.group(0).toLowerCase() }))
-  object KebabCase extends NamingStrategy(x ⇒ regex.replaceAllIn(x, { m ⇒ "-" + m.group(0).toLowerCase() }))
-  object LowerCase extends NamingStrategy(x ⇒ regex.replaceAllIn(x, { m ⇒ m.group(0).toLowerCase() }))
-  object UpperCamelCase extends NamingStrategy(x ⇒ {
+  object SnakeCase extends NamingStrategy(x => regex.replaceAllIn(x, { m => "_" + m.group(0).toLowerCase() }))
+  object KebabCase extends NamingStrategy(x => regex.replaceAllIn(x, { m => "-" + m.group(0).toLowerCase() }))
+  object LowerCase extends NamingStrategy(x => regex.replaceAllIn(x, { m => m.group(0).toLowerCase() }))
+  object UpperCamelCase extends NamingStrategy(x => {
         val (head, tail) = x.splitAt(1)
         head.toUpperCase() + tail
       })
@@ -23,11 +23,11 @@ object NamingStrategy {
       )
 
   def from(naming: String): NamingStrategy = naming match {
-    case "snake_case" ⇒ SnakeCase
+    case "snake_case" => SnakeCase
     case "snake_case_skip_number" => SnakeCaseSkipNumber
-    case "kebab-case" ⇒ KebabCase
-    case "lowercase" ⇒ LowerCase
-    case "UpperCamelCase" ⇒ UpperCamelCase
-    case _ ⇒ None
+    case "kebab-case" => KebabCase
+    case "lowercase" => LowerCase
+    case "UpperCamelCase" => UpperCamelCase
+    case _ => None
   }
 }

--- a/core/src/main/scala/com/iheart/playSwagger/OutputTransformer.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/OutputTransformer.scala
@@ -7,24 +7,24 @@ import com.iheart.playSwagger.OutputTransformer.SimpleOutputTransformer
 import play.api.libs.json.{JsArray, JsObject, JsString, JsValue}
 
 /** Specialization of a Kleisli function (A => M[B]) */
-trait OutputTransformer extends (JsObject ⇒ Try[JsObject]) {
+trait OutputTransformer extends (JsObject => Try[JsObject]) {
 
   /** alias for `andThen` as defined monadic function */
-  def >=>(b: JsObject ⇒ Try[JsObject]): OutputTransformer = SimpleOutputTransformer { value: JsObject ⇒
+  def >=>(b: JsObject => Try[JsObject]): OutputTransformer = SimpleOutputTransformer { value: JsObject =>
     this.apply(value).flatMap(b)
   }
 }
 
 object OutputTransformer {
-  final case class SimpleOutputTransformer(run: (JsObject ⇒ Try[JsObject])) extends OutputTransformer {
+  final case class SimpleOutputTransformer(run: (JsObject => Try[JsObject])) extends OutputTransformer {
     override def apply(value: JsObject): Try[JsObject] = run(value)
   }
 
-  def traverseTransformer(vals: JsArray)(transformer: JsValue ⇒ Try[JsValue]): Try[JsArray] = {
+  def traverseTransformer(vals: JsArray)(transformer: JsValue => Try[JsValue]): Try[JsArray] = {
     val tryElements = vals.value.map {
-      case value: JsObject ⇒ traverseTransformer(value)(transformer)
-      case value: JsArray ⇒ traverseTransformer(value)(transformer)
-      case value: JsValue ⇒ transformer(value)
+      case value: JsObject => traverseTransformer(value)(transformer)
+      case value: JsArray => traverseTransformer(value)(transformer)
+      case value: JsValue => transformer(value)
     }.toList
 
     val failures: List[Failure[JsValue]] =
@@ -36,11 +36,11 @@ object OutputTransformer {
     }
   }
 
-  def traverseTransformer(obj: JsObject)(transformer: JsValue ⇒ Try[JsValue]): Try[JsObject] = {
+  def traverseTransformer(obj: JsObject)(transformer: JsValue => Try[JsValue]): Try[JsObject] = {
     val tryFields = obj.fields.map {
-      case (key, value: JsObject) ⇒ (key, traverseTransformer(value)(transformer))
-      case (key, values: JsArray) ⇒ (key, traverseTransformer(values)(transformer))
-      case (key, value: JsValue) ⇒ (key, transformer(value))
+      case (key, value: JsObject) => (key, traverseTransformer(value)(transformer))
+      case (key, values: JsArray) => (key, traverseTransformer(values)(transformer))
+      case (key, value: JsValue) => (key, transformer(value))
     }
     val failures: Seq[(String, Failure[JsValue])] = tryFields
       .filter(_._2.isInstanceOf[Failure[_]])
@@ -49,25 +49,25 @@ object OutputTransformer {
       Failure(failures.head._2.exception)
     } else {
       Success(JsObject(tryFields.asInstanceOf[Seq[(String, Success[JsValue])]].map {
-        case (key, Success(result)) ⇒ (key, result)
+        case (key, Success(result)) => (key, result)
       }))
     }
   }
 }
 
-class PlaceholderVariablesTransformer(map: String ⇒ Option[String], pattern: Regex = "^\\$\\{(.*)\\}$".r)
+class PlaceholderVariablesTransformer(map: String => Option[String], pattern: Regex = "^\\$\\{(.*)\\}$".r)
     extends OutputTransformer {
   def apply(value: JsObject): Try[JsObject] = OutputTransformer.traverseTransformer(value) {
-    case JsString(pattern(key)) ⇒ map(key) match {
-        case Some(result) ⇒ Success(JsString(result))
-        case None ⇒ Failure(new IllegalStateException(s"Unable to find variable $key"))
+    case JsString(pattern(key)) => map(key) match {
+        case Some(result) => Success(JsString(result))
+        case None => Failure(new IllegalStateException(s"Unable to find variable $key"))
       }
-    case e: JsValue ⇒ Success(e)
+    case e: JsValue => Success(e)
   }
 }
 
 final case class MapVariablesTransformer(map: Map[String, String]) extends PlaceholderVariablesTransformer(map.get)
-class EnvironmentVariablesTransformer extends PlaceholderVariablesTransformer((key: String) ⇒
+class EnvironmentVariablesTransformer extends PlaceholderVariablesTransformer((key: String) =>
       Option(System.getenv(key))
     )
 
@@ -76,15 +76,15 @@ class ParametricTypeNamesTransformer extends OutputTransformer {
 
   private def tf(obj: JsObject): JsObject = JsObject {
     obj.fields.map {
-      case (key, value: JsObject) ⇒ (normalize(key), tf(value))
-      case (key, JsString(value)) ⇒ (normalize(key), JsString(normalize(value)))
-      case (key, other) ⇒ (normalize(key), other)
-      case e ⇒ e
+      case (key, value: JsObject) => (normalize(key), tf(value))
+      case (key, JsString(value)) => (normalize(key), JsString(normalize(value)))
+      case (key, other) => (normalize(key), other)
+      case e => e
     }
   }
 
-  private final val normalize: String ⇒ String = {
-    case ParametricType.ParametricTypeClassName(className, argsGroup) ⇒
+  private final val normalize: String => String = {
+    case ParametricType.ParametricTypeClassName(className, argsGroup) =>
       val normalizedArgs =
         argsGroup
           .split(",")
@@ -93,6 +93,6 @@ class ParametricTypeNamesTransformer extends OutputTransformer {
           .map(normalize)
           .mkString("_")
       s"$className-$normalizedArgs"
-    case n ⇒ n
+    case n => n
   }
 }

--- a/core/src/main/scala/com/iheart/playSwagger/ParametricType.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/ParametricType.scala
@@ -12,15 +12,15 @@ case class ParametricType private (
     className: String,
     typeArgsMapping: Map[Line, String]
 ) {
-  val resolve: String ⇒ String = {
-    case ParametricTypeClassName(className, typeArgs) ⇒
+  val resolve: String => String = {
+    case ParametricTypeClassName(className, typeArgs) =>
       val resolvedTypes =
         typeArgs
           .split(",")
           .map(_.trim)
-          .map(tn ⇒ typeArgsMapping.getOrElse(tn, resolve(tn)))
+          .map(tn => typeArgsMapping.getOrElse(tn, resolve(tn)))
       s"$className[${resolvedTypes.mkString(",")}]"
-    case cn ⇒ typeArgsMapping.getOrElse(cn, cn)
+    case cn => typeArgsMapping.getOrElse(cn, cn)
   }
 }
 
@@ -30,13 +30,13 @@ object ParametricType {
   def apply(reifiedTypeName: String)(implicit cl: ClassLoader): ParametricType = {
     val mirror = runtimeMirror(cl)
     reifiedTypeName match {
-      case ParametricTypeClassName(className, typeArgsStr) ⇒
+      case ParametricTypeClassName(className, typeArgsStr) =>
         val sym = mirror.staticClass(className)
         val tpe = sym.selfType
         val typeArgs = typeArgsStr.split(",").map(_.trim).toList
         val typeArgsMapping = SortedMap(tpe.typeArgs.map(_.toString).zip(typeArgs): _*)
         ParametricType(tpe, reifiedTypeName, className, typeArgsMapping)
-      case className ⇒
+      case className =>
         val sym = mirror.staticClass(className)
         val tpe = sym.selfType
         ParametricType(tpe, className, className, SortedMap.empty)

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -36,20 +36,20 @@ object SwaggerParameterMapper {
     val typeName = removeKnownPrefixes(parameter.typeName)
 
     val defaultValueO: Option[JsValue] = {
-      parameter.default.map { value ⇒
+      parameter.default.map { value =>
         typeName match {
-          case ci"Int" | ci"Long" ⇒ JsNumber(value.toLong)
-          case ci"Double" | ci"Float" | ci"BigDecimal" ⇒ JsNumber(value.toDouble)
-          case ci"Boolean" ⇒ JsBoolean(value.toBoolean)
-          case ci"String" ⇒ {
+          case ci"Int" | ci"Long" => JsNumber(value.toLong)
+          case ci"Double" | ci"Float" | ci"BigDecimal" => JsNumber(value.toDouble)
+          case ci"Boolean" => JsBoolean(value.toBoolean)
+          case ci"String" => {
             val noquotes = value match {
-              case c if c.startsWith("\"\"\"") && c.endsWith("\"\"\"") ⇒ c.substring(3, c.length - 3)
-              case c if c.startsWith("\"") && c.endsWith("\"") ⇒ c.substring(1, c.length - 1)
-              case c ⇒ c
+              case c if c.startsWith("\"\"\"") && c.endsWith("\"\"\"") => c.substring(3, c.length - 3)
+              case c if c.startsWith("\"") && c.endsWith("\"") => c.substring(1, c.length - 1)
+              case c => c
             }
             JsString(noquotes)
           }
-          case _ ⇒ JsString(value)
+          case _ => JsString(value)
         }
       }
     }
@@ -70,9 +70,9 @@ object SwaggerParameterMapper {
       )
 
     val enumParamMF: MappingFunction = {
-      case JavaEnum(enumConstants) ⇒ genSwaggerParameter("string", enum = Option(enumConstants))
-      case ScalaEnum(enumConstants) ⇒ genSwaggerParameter("string", enum = Option(enumConstants))
-      case EnumeratumEnum(enumConstants) ⇒ genSwaggerParameter("string", enum = Option(enumConstants))
+      case JavaEnum(enumConstants) => genSwaggerParameter("string", enum = Option(enumConstants))
+      case ScalaEnum(enumConstants) => genSwaggerParameter("string", enum = Option(enumConstants))
+      case EnumeratumEnum(enumConstants) => genSwaggerParameter("string", enum = Option(enumConstants))
     }
 
     def isReference(tpeName: String = typeName): Boolean = modelQualifier.isModel(tpeName)
@@ -97,37 +97,37 @@ object SwaggerParameterMapper {
       asRequired.update(required = false, nullable = true, default = asRequired.default)
     }
 
-    def updateGenParam(param: SwaggerParameter)(update: GenSwaggerParameter ⇒ GenSwaggerParameter): SwaggerParameter =
+    def updateGenParam(param: SwaggerParameter)(update: GenSwaggerParameter => GenSwaggerParameter): SwaggerParameter =
       param match {
-        case p: GenSwaggerParameter ⇒ update(p)
-        case _ ⇒ param
+        case p: GenSwaggerParameter => update(p)
+        case _ => param
       }
 
     val referenceParamMF: MappingFunction = {
-      case tpe if isReference(tpe) ⇒ referenceParam(tpe)
+      case tpe if isReference(tpe) => referenceParam(tpe)
     }
 
     val optionalParamMF: MappingFunction = {
-      case tpe if higherOrderType("Option", typeName, None).isDefined ⇒
+      case tpe if higherOrderType("Option", typeName, None).isDefined =>
         optionalParam(higherOrderType("Option", typeName, None).get)
     }
 
     val generalParamMF: MappingFunction = {
-      case ci"Int" | ci"Integer" ⇒ genSwaggerParameter("integer", Some("int32"))
-      case ci"Long" ⇒ genSwaggerParameter("integer", Some("int64"))
-      case ci"Double" | ci"BigDecimal" ⇒ genSwaggerParameter("number", Some("double"))
-      case ci"Float" ⇒ genSwaggerParameter("number", Some("float"))
-      case ci"DateTime" ⇒ genSwaggerParameter("integer", Some("epoch"))
-      case ci"java.time.Instant" ⇒ genSwaggerParameter("string", Some("date-time"))
-      case ci"java.time.LocalDate" ⇒ genSwaggerParameter("string", Some("date"))
-      case ci"java.time.LocalDateTime" ⇒ genSwaggerParameter("string", Some("date-time"))
-      case ci"java.time.Duration" ⇒ genSwaggerParameter("string")
-      case ci"Any" ⇒ genSwaggerParameter("any").copy(example = Some(JsString("any JSON value")))
-      case unknown ⇒ genSwaggerParameter(unknown.toLowerCase())
+      case ci"Int" | ci"Integer" => genSwaggerParameter("integer", Some("int32"))
+      case ci"Long" => genSwaggerParameter("integer", Some("int64"))
+      case ci"Double" | ci"BigDecimal" => genSwaggerParameter("number", Some("double"))
+      case ci"Float" => genSwaggerParameter("number", Some("float"))
+      case ci"DateTime" => genSwaggerParameter("integer", Some("epoch"))
+      case ci"java.time.Instant" => genSwaggerParameter("string", Some("date-time"))
+      case ci"java.time.LocalDate" => genSwaggerParameter("string", Some("date"))
+      case ci"java.time.LocalDateTime" => genSwaggerParameter("string", Some("date-time"))
+      case ci"java.time.Duration" => genSwaggerParameter("string")
+      case ci"Any" => genSwaggerParameter("any").copy(example = Some(JsString("any JSON value")))
+      case unknown => genSwaggerParameter(unknown.toLowerCase())
     }
 
     val itemsParamMF: MappingFunction = {
-      case tpe if collectionItemType(tpe).isDefined ⇒
+      case tpe if collectionItemType(tpe).isDefined =>
         // TODO: This could use a different type to represent ItemsObject(http://swagger.io/specification/#itemsObject),
         // since the structure is not quite the same, and still has to be handled specially in a json transform (see propWrites in SwaggerSpecGenerator)
         // However, that spec conflicts with example code elsewhere that shows other fields in the object, such as properties:
@@ -139,10 +139,10 @@ object SwaggerParameterMapper {
         ))
     }
 
-    val customMappingMF: MappingFunction = customMappings.map { mapping ⇒
+    val customMappingMF: MappingFunction = customMappings.map { mapping =>
       val re = StringContext(removeKnownPrefixes(mapping.`type`)).ci
       val mf: MappingFunction = {
-        case re() ⇒
+        case re() =>
           CustomSwaggerParameter(
             parameter.name,
             mapping.specAsParameter,

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
@@ -19,15 +19,15 @@ object SwaggerSpecRunner extends App {
     val swaggerPlayJava = java.lang.Boolean.parseBoolean(swaggerPlayJavaString)
     val domainModelQualifier = PrefixDomainModelQualifier(domainNameSpaceArgs.split(","): _*)
     val transformersStrs: Seq[String] = if (outputTransformersArgs.isEmpty) Seq() else outputTransformersArgs.split(",")
-    val transformers = transformersStrs.map { clazz ⇒
+    val transformers = transformersStrs.map { clazz =>
       Try(cl.loadClass(clazz).asSubclass(classOf[OutputTransformer]).newInstance()) match {
-        case Failure(ex: ClassCastException) ⇒
+        case Failure(ex: ClassCastException) =>
           throw new IllegalArgumentException(
             "Transformer should be a subclass of com.iheart.playSwagger.OutputTransformer:" + clazz,
             ex
           )
-        case Failure(ex) ⇒ throw new IllegalArgumentException("Could not create transformer", ex)
-        case Success(el) ⇒ el
+        case Failure(ex) => throw new IllegalArgumentException("Could not create transformer", ex)
+        case Success(el) => el
       }
     }
     val swaggerSpec: JsValue = SwaggerSpecGenerator(

--- a/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
@@ -282,7 +282,7 @@ class DefinitionGeneratorSpec extends Specification {
 
       }
       "with override" >> {
-        val customJson = List(Json.obj("type" → "string", "format" → "date-time"))
+        val customJson = List(Json.obj("type" -> "string", "format" -> "date-time"))
         val mappings = List(
           CustomTypeMapping(
             `type` = "org.joda.time.DateTime",
@@ -299,7 +299,7 @@ class DefinitionGeneratorSpec extends Specification {
     }
     "with optional date" >> {
       "with override" >> {
-        val customJson = List(Json.obj("type" → "string", "format" → "date-time"))
+        val customJson = List(Json.obj("type" -> "string", "format" -> "date-time"))
         val mappings = List(
           CustomTypeMapping(
             `type` = "org.joda.time.DateTime",
@@ -316,7 +316,7 @@ class DefinitionGeneratorSpec extends Specification {
     }
 
     "with property overrides" >> {
-      val customJson = List(Json.obj("type" → "string"))
+      val customJson = List(Json.obj("type" -> "string"))
       val customMapping = CustomTypeMapping(
         `type` = "com.iheart.playSwagger.WrappedString",
         specAsParameter = customJson

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -20,7 +20,7 @@ class SwaggerParameterMapperSpec extends Specification {
 
     "override mapping to map DateTime to string with format date-time" >> {
       "single DateTime" >> {
-        val specAsParameter = List(Json.obj("type" → "string", "format" → "date-time"))
+        val specAsParameter = List(Json.obj("type" -> "string", "format" -> "date-time"))
         val mappings: CustomMappings = List(CustomTypeMapping(
           "org.joda.time.DateTime",
           specAsParameter = specAsParameter
@@ -36,7 +36,7 @@ class SwaggerParameterMapperSpec extends Specification {
       }
 
       "sequence of DateTimes" >> {
-        val specAsProperty = Json.obj("type" → "string", "format" → "date-time")
+        val specAsProperty = Json.obj("type" -> "string", "format" -> "date-time")
         val mappings: CustomMappings = List(CustomTypeMapping(
           "org.joda.time.DateTime",
           specAsProperty = Some(specAsProperty)
@@ -58,7 +58,7 @@ class SwaggerParameterMapperSpec extends Specification {
     }
 
     "add new custom type mapping" >> {
-      val specAsParameter = List(Json.obj("type" → "string", "format" → "date-time"))
+      val specAsParameter = List(Json.obj("type" -> "string", "format" -> "date-time"))
       val mappings: CustomMappings = List(CustomTypeMapping(
         "java.util.Date",
         specAsParameter = specAsParameter
@@ -126,7 +126,7 @@ class SwaggerParameterMapperSpec extends Specification {
 
     "map String to string without override interference" >> {
 
-      val specAsParameter = List(Json.obj("type" → "string", "format" → "date-time"))
+      val specAsParameter = List(Json.obj("type" -> "string", "format" -> "date-time"))
       val mappings: CustomMappings = List(
         CustomTypeMapping(
           "java.time.LocalDate",

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -92,7 +92,7 @@ class SwaggerSpecGeneratorSpec extends Specification {
       val mappings = result.get
       mappings.size must be_>(2)
       mappings.head.`type` mustEqual "java\\.time\\.LocalDate"
-      mappings.head.specAsParameter === List(Json.obj("type" → "string", "format" → "date"))
+      mappings.head.specAsParameter === List(Json.obj("type" -> "string", "format" -> "date"))
       mappings.head.specAsProperty must beEmpty
 
     }
@@ -329,7 +329,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     "generate tags definition" >> {
       val tags = (json \ "tags").asOpt[Seq[JsObject]]
       tags must beSome[Seq[JsObject]]
-      tags.get.map(tO ⇒ (tO \ "name").as[String]).sorted must containAllOf(Seq(
+      tags.get.map(tO => (tO \ "name").as[String]).sorted must containAllOf(Seq(
         "customResource",
         "liveMeta",
         "player",
@@ -340,14 +340,14 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     "merge tag description from base" >> {
       val tags = (json \ "tags").asOpt[Seq[JsObject]]
       tags must beSome[Seq[JsObject]]
-      val playTag = tags.get.find(t ⇒ (t \ "name").as[String] == "player")
+      val playTag = tags.get.find(t => (t \ "name").as[String] == "player")
       (playTag.get \ "description").asOpt[String] === Some("this is player api")
     }
 
     "get both body and url params" >> {
       val params = (playerAddTrackJson \ "parameters").as[JsArray].value
       params.length === 2
-      params.map(p ⇒ (p \ "name").as[String]).toSet === Set("body", "pid")
+      params.map(p => (p \ "name").as[String]).toSet === Set("body", "pid")
 
     }
 
@@ -575,17 +575,17 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
 
     "excluded domain object should contain only spec from swagger.json" >> {
       overriddenDictTypeJson === Json.obj(
-        "type" → "object",
-        "properties" → Json.obj(
-          "id" → Json.obj("type" → "string"),
-          "value" → Json.obj("type" → "string")
+        "type" -> "object",
+        "properties" -> Json.obj(
+          "id" -> Json.obj("type" -> "string"),
+          "value" -> Json.obj("type" -> "string")
         )
       )
     }
 
     "definition properties does not contain 'required' boolean field" >> {
-      definitionsJson.as[JsObject].values.forall { definition ⇒
-        (definition \ "properties").as[JsObject].values.forall { property ⇒
+      definitionsJson.as[JsObject].values.forall { definition =>
+        (definition \ "properties").as[JsObject].values.forall { property =>
           (property \ "required").toOption === None
         }
       }
@@ -620,7 +620,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
 
     "not contain tags that are empty" >> {
       val tags = (json \ "tags").as[Seq[JsObject]]
-        .map(o ⇒ (o \ "name").as[String])
+        .map(o => (o \ "name").as[String])
       tags must not contain "no"
     }
 
@@ -633,12 +633,12 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
     "accept parameter references" >> {
       val parameters = (pathJson \ "/references/magic/echoMagic/{type}" \ "post" \ "parameters").as[Seq[JsObject]]
 
-      parameters must contain((entry: JsObject) ⇒
+      parameters must contain((entry: JsObject) =>
         entry.value.get("$ref").contains(JsString("#/parameters/magic"))
       )
         .exactly(1.times)
 
-      parameters must contain((entry: JsObject) ⇒
+      parameters must contain((entry: JsObject) =>
         entry.value.get("name").contains(JsString("notMagic"))
       )
         .exactly(1.times)
@@ -648,7 +648,7 @@ class SwaggerSpecGeneratorIntegrationSpec extends Specification {
 
       val parameters = (pathJson \ "/zoo/zone/{zid}/animals/{aid}" \ "get" \ "parameters").as[Seq[JsObject]]
       parameters.size === 1
-      parameters must contain((entry: JsObject) ⇒
+      parameters must contain((entry: JsObject) =>
         entry.value.get("name").contains(JsString("aid"))
       )
         .exactly(1.times).not

--- a/example/app/controllers/AsyncController.scala
+++ b/example/app/controllers/AsyncController.scala
@@ -34,7 +34,7 @@ exec: ExecutionContext) extends AbstractController(components) {
     * a path of `/message`.
     */
   def message: Action[AnyContent] = Action.async {
-    getFutureMessage(1.second).map { msg ⇒ Ok(Json.toJson(msg)) }
+    getFutureMessage(1.second).map { msg => Ok(Json.toJson(msg)) }
   }
 
   private def getFutureMessage(delayTime: FiniteDuration): Future[Message] = {

--- a/example/app/filters/ExampleFilter.scala
+++ b/example/app/filters/ExampleFilter.scala
@@ -23,11 +23,11 @@ class ExampleFilter @Inject() (
     exec: ExecutionContext
 ) extends Filter {
 
-  override def apply(nextFilter: RequestHeader ⇒ Future[Result])(requestHeader: RequestHeader): Future[Result] = {
+  override def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = {
     // Run the next filter in the chain. This will call other filters
     // and eventually call the action. Take the result and modify it
     // by adding a new header.
-    nextFilter(requestHeader).map { result ⇒
+    nextFilter(requestHeader).map { result =>
       result.withHeaders("X-ExampleFilter" -> "foo")
     }
   }

--- a/example/app/services/ApplicationTimer.scala
+++ b/example/app/services/ApplicationTimer.scala
@@ -34,7 +34,7 @@ class ApplicationTimer @Inject() (clock: Clock, appLifecycle: ApplicationLifecyc
   // When the application starts, register a stop hook with the
   // ApplicationLifecycle object. The code inside the stop hook will
   // be run when the application stops.
-  appLifecycle.addStopHook { () ⇒
+  appLifecycle.addStopHook { () =>
     val stop: Instant = clock.instant
     val runningTime: Long = stop.getEpochSecond - start.getEpochSecond
     logger.info(s"ApplicationTimer demo: Stopping application at ${clock.instant} after ${runningTime}s.")

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 scalafixDependencies in ThisBuild ++= Seq(
   "com.github.liancheng" %% "organize-imports" % "0.6.0",
-  "net.pixiv" %% "scalafix-pixiv-rule" % "2.2.0"
+  "net.pixiv" %% "scalafix-pixiv-rule" % "2.4.0"
 )
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala, SwaggerPlugin) //enable plugin

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
@@ -64,7 +64,7 @@ object SwaggerPlugin extends AutoPlugin {
       file
     }.value,
     unmanagedResourceDirectories in Assets += swaggerTarget.value,
-    mappings in (Compile, packageBin) += (swagger.value) → s"public/${swaggerFileName.value}", // include it in the unmanagedResourceDirectories in Assets doesn't automatically include it package
+    mappings in (Compile, packageBin) += (swagger.value) -> s"public/${swaggerFileName.value}", // include it in the unmanagedResourceDirectories in Assets doesn't automatically include it package
     packageBin in Universal := (packageBin in Universal).dependsOn(swagger).value,
     run := (run in Compile).dependsOn(swagger).evaluated,
     stage := stage.dependsOn(swagger).value


### PR DESCRIPTION
Symbols such as ⇒ and →, while visually pleasing, are very time-consuming in terms of typing.
I would like to replace them with => and -> since I have created a system that allows substitution and monitoring with scalafix rules.