### PR TITLE
fix: Apply Scaladoc comments to Option type fields as well

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -92,7 +92,8 @@ object SwaggerParameterMapper {
           }
         ),
         modelQualifier = modelQualifier,
-        customMappings = customMappings
+        customMappings = customMappings,
+        description = description
       )
       asRequired.update(required = false, nullable = true, default = asRequired.default)
     }

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerSpecGeneratorSpec.scala
@@ -22,7 +22,7 @@ case class Subject(name: String)
 /**
   * @param name e.g. Sunday, Monday, TuesDay...
   */
-case class DayOfWeek(name: String)
+case class DayOfWeek(name: Option[String])
 
 case class PolymorphicContainer(item: PolymorphicItem)
 trait PolymorphicItem


### PR DESCRIPTION
Fixed #499, where comments could not be added to Option type parameters.