### PR TITLE
Match a default value of "null" to JsNull

### DIFF
--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -37,19 +37,22 @@ object SwaggerParameterMapper {
 
     val defaultValueO: Option[JsValue] = {
       parameter.default.map { value =>
-        typeName match {
-          case ci"Int" | ci"Long" => JsNumber(value.toLong)
-          case ci"Double" | ci"Float" | ci"BigDecimal" => JsNumber(value.toDouble)
-          case ci"Boolean" => JsBoolean(value.toBoolean)
-          case ci"String" => {
-            val noquotes = value match {
-              case c if c.startsWith("\"\"\"") && c.endsWith("\"\"\"") => c.substring(3, c.length - 3)
-              case c if c.startsWith("\"") && c.endsWith("\"") => c.substring(1, c.length - 1)
-              case c => c
-            }
-            JsString(noquotes)
+        if (value.equals("null")) {
+          JsNull
+        } else {
+          typeName match {
+            case ci"Int" | ci"Long" => JsNumber(value.toLong)
+            case ci"Double" | ci"Float" | ci"BigDecimal" => JsNumber(value.toDouble)
+            case ci"Boolean" => JsBoolean(value.toBoolean)
+            case ci"String" =>
+              val unquotedString = value match {
+                case c if c.startsWith("\"\"\"") && c.endsWith("\"\"\"") => c.substring(3, c.length - 3)
+                case c if c.startsWith("\"") && c.endsWith("\"") => c.substring(1, c.length - 1)
+                case c => c
+              }
+              JsString(unquotedString)
+            case _ => JsString(value)
           }
-          case _ => JsString(value)
         }
       }
     }


### PR DESCRIPTION
A route with a null default parameter (for example: "parameter: java.lang.Boolean ?= null") leads to an IllegalArgumentException:
[error] stack trace is suppressed; run last swagger for the full output
[error] (swagger) java.lang.IllegalArgumentException: For input string: "null"
[error] Total time: 10 s, completed May 5, 2023, 9:40:12 AM

The IllegalArgumentException occurs as the string value "null" cannot be cast to JsBoolean (value.toBoolean).

While working out a fix, I stumbled upon: https://github.com/iheartradio/play-swagger/issues/132

This should resolve both issues – an unquoted string (?= null) will be cast to JsNull, a quoted string (?= "null") will be treated as-is.

