### PR TITLE
As of Play 2.9 "routes-compiler" now has the "play-" prefix too

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   )
 
   val playRoutesCompiler = Seq(
-    "com.typesafe.play" %% "routes-compiler" % Versions.play
+    "com.typesafe.play" %% "play-routes-compiler" % Versions.play
   )
 
   val playJson = Seq(


### PR DESCRIPTION
Hi, Play maintainer here. Play 2.9 is not released yet but will be soon. This is just a note that when you upgrade that this artifact was renamed. See https://github.com/playframework/playframework/pull/11927
All the best!